### PR TITLE
chore(monorepo): prepare npm prerelease bootstrap flow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -165,6 +165,7 @@ jobs:
         run: ./scripts/smoke_npm_registry_install.sh "${GITHUB_REF_NAME}" "${{ matrix.target }}"
 
   publish-npm:
+    if: vars.NPM_PUBLISH_ENABLED == 'true'
     needs:
       - build-leaf-packages
       - build-root-package
@@ -172,6 +173,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     defaults:
       run:
         shell: bash
@@ -189,9 +191,16 @@ jobs:
           pattern: npm-*
           merge-multiple: true
 
+      - name: Select npm dist-tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "NPM_DIST_TAG=next" >>"$GITHUB_ENV"
+          else
+            echo "NPM_DIST_TAG=latest" >>"$GITHUB_ENV"
+          fi
+
       - name: Publish npm packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           for tarball in \
@@ -201,5 +210,5 @@ jobs:
             "dist/npm/olhapi-maestro-linux-arm64-gnu-${VERSION}.tgz" \
             "dist/npm/olhapi-maestro-win32-x64-${VERSION}.tgz" \
             "dist/npm/olhapi-maestro-${VERSION}.tgz"; do
-            npm publish --access public "$tarball"
+            npm publish --access public --provenance --tag "$NPM_DIST_TAG" "$tarball"
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 - never run "--no-verify", if coverage is missing or there are errors then they should be fixed
 - you must use conventional commits style with a monorepo scope for each commit message
+- when asked to commit, you need to create a feature branch, commit all changes, push and create a PR with auto-merge setting
 - do not write simplified test just for making them pass, tests should be written in order to verify the expected logic

--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ Maestro stays local-first even when a project syncs issues from Linear. Provider
 
 ### npm
 
-Preferred install on supported platforms:
+Current public prerelease install on supported platforms:
 
 ```bash
-npm install -g @olhapi/maestro
+npm install -g @olhapi/maestro@next
 ```
 
-Update an existing install:
+Refresh an existing prerelease install:
 
 ```bash
-npm update -g @olhapi/maestro
+npm install -g @olhapi/maestro@next
 ```
 
 The installed command name is still `maestro`.
+
+Until the first stable release ships, the npm prerelease channel is published on `next`. After `v0.1.0`, `npm install -g @olhapi/maestro` will follow the stable `latest` channel.
 
 Official npm builds currently cover:
 
@@ -264,6 +266,7 @@ Missing-file behavior differs by command:
 ## More Documentation
 
 - [`docs/OPERATIONS.md`](docs/OPERATIONS.md): runtime surfaces, HTTP endpoints, extension tools, logs, and operational details
+- [`docs/NPM_RELEASE.md`](docs/NPM_RELEASE.md): first npm prerelease bootstrap and the trusted-publishing release flow
 - [`docs/E2E_REAL_CODEX.md`](docs/E2E_REAL_CODEX.md): end-to-end harness that runs the real Codex CLI against deterministic issues
 - [`WORKFLOW.md`](WORKFLOW.md): the workflow configuration used by this repository
 

--- a/apps/website/src/content/docs/install.mdx
+++ b/apps/website/src/content/docs/install.mdx
@@ -8,17 +8,19 @@ navLabel: Install
 
 import DocsCommandField from "./_components/DocsCommandField.astro";
 
-## Preferred install path
+## Current prerelease install path
 
-If you are on a supported platform, the fastest path is the published npm package:
+If you are on a supported platform, the current public prerelease is the fastest path:
 
-<DocsCommandField command={`npm install -g @olhapi/maestro`} />
+<DocsCommandField command={`npm install -g @olhapi/maestro@next`} />
 
-Update an existing global install with:
+Refresh an existing prerelease install with:
 
-<DocsCommandField command={`npm update -g @olhapi/maestro`} />
+<DocsCommandField command={`npm install -g @olhapi/maestro@next`} />
 
 The installed command name is still `maestro`.
+
+Until `v0.1.0` ships, the npm release channel is `next`. After the first stable release, `npm install -g @olhapi/maestro` will follow the stable `latest` channel.
 
 Official npm builds currently cover:
 

--- a/apps/website/src/site.config.ts
+++ b/apps/website/src/site.config.ts
@@ -25,9 +25,9 @@ export const durableSurfaces = [
 export const quickstartSteps = [
   {
     title: "Install",
-    command: "npm install -g @olhapi/maestro",
+    command: "npm install -g @olhapi/maestro@next",
     detail:
-      "Preferred global install for macOS arm64/x64, Linux glibc arm64/x64, and Windows x64.",
+      "Current prerelease global install for macOS arm64/x64, Linux glibc arm64/x64, and Windows x64 until v0.1.0 ships.",
   },
   {
     title: "Bootstrap workflow",

--- a/docs/NPM_RELEASE.md
+++ b/docs/NPM_RELEASE.md
@@ -1,0 +1,94 @@
+# npm Release Runbook
+
+This runbook covers the first public npm publish for Maestro and the steady-state tag flow after trusted publishing is enabled.
+
+## First public prerelease bootstrap
+
+Leave the GitHub repository variable `NPM_PUBLISH_ENABLED` unset or set to `false`. The release workflow will still build all five native tarballs, build the root package, and run both smoke-test stages, but the `publish-npm` job will stay skipped until trusted publishing is ready.
+
+Cut and push the first public tag:
+
+```bash
+git tag v0.1.0-rc.1
+git push origin v0.1.0-rc.1
+```
+
+Wait for the `Release npm Package` workflow to finish these jobs successfully:
+
+- `go-test`
+- `build-leaf-packages`
+- `build-root-package`
+- `registry-install-smoke`
+
+Download the six npm artifacts from that workflow run:
+
+- `npm-leaf-darwin-arm64`
+- `npm-leaf-darwin-x64`
+- `npm-leaf-linux-x64-gnu`
+- `npm-leaf-linux-arm64-gnu`
+- `npm-leaf-win32-x64`
+- `npm-root-package`
+
+On a maintainer machine that is already logged in to npm for the `@olhapi` scope with 2FA enabled, publish the five leaf tarballs first, then publish the root tarball last so its optional dependencies already exist:
+
+```bash
+VERSION=0.1.0-rc.1
+
+for tarball in \
+  "dist/npm/olhapi-maestro-darwin-arm64-${VERSION}.tgz" \
+  "dist/npm/olhapi-maestro-darwin-x64-${VERSION}.tgz" \
+  "dist/npm/olhapi-maestro-linux-x64-gnu-${VERSION}.tgz" \
+  "dist/npm/olhapi-maestro-linux-arm64-gnu-${VERSION}.tgz" \
+  "dist/npm/olhapi-maestro-win32-x64-${VERSION}.tgz"; do
+  npm publish --access public --tag next "$tarball"
+done
+
+npm publish --access public --tag next "dist/npm/olhapi-maestro-${VERSION}.tgz"
+```
+
+Verify the bootstrap publish before enabling CI publishing:
+
+```bash
+npm view @olhapi/maestro dist-tags --json
+npm view @olhapi/maestro-darwin-arm64 version
+npm view @olhapi/maestro-darwin-x64 version
+npm view @olhapi/maestro-linux-x64-gnu version
+npm view @olhapi/maestro-linux-arm64-gnu version
+npm view @olhapi/maestro-win32-x64 version
+npm install -g @olhapi/maestro@next
+maestro version
+```
+
+The root package should report `next: 0.1.0-rc.1`, every leaf package should exist at `0.1.0-rc.1`, and the installed CLI should report `maestro 0.1.0-rc.1`.
+
+## Enable trusted publishing
+
+After the bootstrap publish succeeds, configure npm trusted publishers for all six packages:
+
+- GitHub owner: `olhapi`
+- GitHub repository: `maestro`
+- Workflow file: `.github/workflows/release-npm.yml`
+- Workflow filename in npm settings: `release-npm.yml`
+
+Repeat that configuration for:
+
+- `@olhapi/maestro`
+- `@olhapi/maestro-darwin-arm64`
+- `@olhapi/maestro-darwin-x64`
+- `@olhapi/maestro-linux-x64-gnu`
+- `@olhapi/maestro-linux-arm64-gnu`
+- `@olhapi/maestro-win32-x64`
+
+Once all six packages trust the release workflow:
+
+1. Set the GitHub repository variable `NPM_PUBLISH_ENABLED=true`.
+2. Leave `NPM_TOKEN` unset; the workflow now publishes through GitHub Actions OIDC.
+3. Keep npm package 2FA protection enabled and remove or restrict legacy automation tokens.
+
+## Ongoing tag flow
+
+Future tags use the same workflow and artifact order:
+
+- prerelease tags such as `v0.1.0-rc.2` publish to the npm `next` dist-tag
+- stable tags such as `v0.1.0` publish to the npm `latest` dist-tag
+- CI publishing uses `npm publish --provenance` with trusted publishing, so no long-lived npm token is required in GitHub Actions


### PR DESCRIPTION
## Summary
- switch the npm release workflow to gated trusted publishing with prerelease dist-tag handling
- add a first-release bootstrap runbook for the npm packages
- update install surfaces to use the prerelease `next` channel until v0.1.0
- include all current local changes in this branch as requested

## Testing
- pnpm verify
- pnpm verify:package
- ./scripts/package_npm_release.sh 0.1.0-rc.0
- ./scripts/smoke_npm_package.sh 0.1.0-rc.0 darwin-arm64
- pnpm verify:website
- pnpm website:build