### PR TITLE
fix(cli): default log level to warn

### DIFF
--- a/apps/website/src/content/docs/cli-reference.mdx
+++ b/apps/website/src/content/docs/cli-reference.mdx
@@ -79,7 +79,7 @@ maestro --log-level <debug|info|warn|error> spec-check [--repo <path>] [--json]
 maestro --log-level <debug|info|warn|error> workflow init [repo_path]`}
 />
 
-`--log-level` defaults to `info`. Use `debug` when you need raw app-server stream output and session churn in the structured logs.
+`--log-level` defaults to `warn`. Use `info` when you want lifecycle and status transition logs, and `debug` when you need raw app-server stream output and session churn in the structured logs.
 
 `maestro run` serves HTTP on port `8787` by default. Pass `--port` only when you want a different port.
 

--- a/cmd/maestro/helpers.go
+++ b/cmd/maestro/helpers.go
@@ -19,7 +19,9 @@ const guardrailsAcknowledgementFlag = "--i-understand-that-this-will-be-running-
 
 func parseLogLevel(raw string) (slog.Level, string, error) {
 	switch normalized := strings.ToLower(strings.TrimSpace(raw)); normalized {
-	case "", "info":
+	case "":
+		return slog.LevelWarn, "warn", nil
+	case "info":
 		return slog.LevelInfo, "info", nil
 	case "debug":
 		return slog.LevelDebug, "debug", nil

--- a/cmd/maestro/main_test.go
+++ b/cmd/maestro/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -72,7 +73,7 @@ func TestParseLogLevelVariants(t *testing.T) {
 		level slog.Level
 		name  string
 	}{
-		{raw: "", level: slog.LevelInfo, name: "info"},
+		{raw: "", level: slog.LevelWarn, name: "warn"},
 		{raw: "info", level: slog.LevelInfo, name: "info"},
 		{raw: "warning", level: slog.LevelWarn, name: "warn"},
 		{raw: "error", level: slog.LevelError, name: "error"},
@@ -85,6 +86,17 @@ func TestParseLogLevelVariants(t *testing.T) {
 		if level != tc.level || name != tc.name {
 			t.Fatalf("parseLogLevel(%q) = (%v, %q), want (%v, %q)", tc.raw, level, name, tc.level, tc.name)
 		}
+	}
+}
+
+func TestRootCommandLogLevelDefaultsToWarn(t *testing.T) {
+	cmd := newRootCmd(io.Discard, io.Discard)
+	flag := cmd.PersistentFlags().Lookup("log-level")
+	if flag == nil {
+		t.Fatal("expected --log-level flag")
+	}
+	if flag.DefValue != "warn" {
+		t.Fatalf("expected --log-level default warn, got %q", flag.DefValue)
 	}
 }
 

--- a/cmd/maestro/root.go
+++ b/cmd/maestro/root.go
@@ -55,7 +55,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		stdout: stdout,
 		stderr: stderr,
 		opts: rootOptions{
-			logLevel: "info",
+			logLevel: "warn",
 		},
 	}
 
@@ -81,7 +81,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	rootCmd.SetErr(stderr)
 	rootCmd.PersistentFlags().StringVar(&app.opts.dbPath, "db", "", "Path to the Maestro SQLite database")
 	rootCmd.PersistentFlags().StringVar(&app.opts.apiURL, "api-url", "", "Base URL for the live Maestro API")
-	rootCmd.PersistentFlags().StringVar(&app.opts.logLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	rootCmd.PersistentFlags().StringVar(&app.opts.logLevel, "log-level", "warn", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().BoolVar(&app.opts.mode.json, "json", false, "Emit machine-readable JSON")
 	rootCmd.PersistentFlags().BoolVar(&app.opts.mode.wide, "wide", false, "Expand text output with extra columns")
 	rootCmd.PersistentFlags().BoolVar(&app.opts.mode.quiet, "quiet", false, "Emit identifiers only in text mode")


### PR DESCRIPTION
## Summary
- default the CLI log level to `warn` so published Maestro runs stay quiet by default
- keep explicit `info` and `debug` logging behavior available for operators
- add regression coverage for the default and update the CLI docs

## Testing
- go test ./...
- repo commit/push hooks (go test ./cmd/maestro, pnpm verify:website, pnpm verify, coverage, race tests)