### PR TITLE
fix(monorepo): resume npm release flow for existing tags

### DIFF
--- a/docs/NPM_RELEASE.md
+++ b/docs/NPM_RELEASE.md
@@ -19,6 +19,8 @@ The script will:
 - verify npm dist-tags when GitHub trusted publishing succeeds
 - fall back to downloading the workflow artifacts and running local `npm publish` in leaf-first order when the workflow build/smoke jobs succeed but `publish-npm` is skipped or fails
 
+If the tag already exists on `origin`, rerunning the helper will resume that release instead of trying to recreate the tag. This is intended for cases where the GitHub workflow finished but npm publish still needs the local artifact fallback.
+
 If the fallback path is used, npm may pause for browser-based account confirmation before it can publish the tarballs.
 
 ## First public prerelease bootstrap

--- a/scripts/publish_npm_release.sh
+++ b/scripts/publish_npm_release.sh
@@ -136,6 +136,37 @@ validate_version() {
   fi
 }
 
+local_tag_target_sha() {
+  git rev-list -n 1 "$TAG"
+}
+
+remote_tag_target_sha() {
+  local remote_refs fallback_sha=""
+  if ! remote_refs="$(git ls-remote --tags origin "refs/tags/$TAG^{}" "refs/tags/$TAG" 2>/dev/null)"; then
+    return 1
+  fi
+
+  local line sha ref
+  while IFS=$'\t' read -r sha ref; do
+    case "$ref" in
+      "refs/tags/$TAG^{}")
+        printf '%s\n' "$sha"
+        return 0
+        ;;
+      "refs/tags/$TAG")
+        fallback_sha="$sha"
+        ;;
+    esac
+  done <<<"$remote_refs"
+
+  if [[ -n "$fallback_sha" ]]; then
+    printf '%s\n' "$fallback_sha"
+    return 0
+  fi
+
+  return 1
+}
+
 ensure_release_branch_state() {
   local current_branch
   current_branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -158,14 +189,48 @@ ensure_release_branch_state() {
   if [[ "$local_head" != "$remote_head" ]]; then
     fail "local main is not aligned with origin/main after pull"
   fi
-  RELEASE_HEAD_SHA="$local_head"
+  CURRENT_HEAD_SHA="$local_head"
+
+  local local_tag_sha="" remote_tag_sha=""
+  local has_local_tag="0"
+  local has_remote_tag="0"
 
   if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
-    fail "tag already exists locally: $TAG"
+    has_local_tag="1"
+    local_tag_sha="$(local_tag_target_sha)"
   fi
-  if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-    fail "tag already exists on origin: $TAG"
+  if remote_tag_sha="$(remote_tag_target_sha)"; then
+    has_remote_tag="1"
   fi
+
+  if [[ "$has_local_tag" == "1" && "$has_remote_tag" == "1" ]]; then
+    if [[ "$local_tag_sha" != "$remote_tag_sha" ]]; then
+      fail "local tag $TAG points to $local_tag_sha but origin points to $remote_tag_sha"
+    fi
+    TAG_TARGET_SHA="$local_tag_sha"
+    CREATE_RELEASE_TAG="0"
+    PUSH_RELEASE_TAG="0"
+    RUN_RELEASE_VERIFICATION="0"
+    log "tag already exists on origin: $TAG (commit $TAG_TARGET_SHA); resuming release flow"
+    return 0
+  fi
+
+  if [[ "$has_local_tag" == "1" ]]; then
+    if [[ "$local_tag_sha" != "$CURRENT_HEAD_SHA" ]]; then
+      fail "local tag $TAG already exists at $local_tag_sha, but current HEAD is $CURRENT_HEAD_SHA"
+    fi
+    TAG_TARGET_SHA="$local_tag_sha"
+    CREATE_RELEASE_TAG="0"
+    PUSH_RELEASE_TAG="1"
+    RUN_RELEASE_VERIFICATION="1"
+    log "tag already exists locally at HEAD: $TAG; reusing it"
+    return 0
+  fi
+
+  TAG_TARGET_SHA="$CURRENT_HEAD_SHA"
+  CREATE_RELEASE_TAG="1"
+  PUSH_RELEASE_TAG="1"
+  RUN_RELEASE_VERIFICATION="1"
 }
 
 find_release_run() {
@@ -340,11 +405,15 @@ main() {
   validate_version "$raw_version"
   VERSION="${raw_version#v}"
   TAG="v$VERSION"
-  RELEASE_HEAD_SHA=""
+  CURRENT_HEAD_SHA=""
+  TAG_TARGET_SHA=""
   RELEASE_RUN_ID=""
   RELEASE_RUN_URL=""
   RELEASE_RUN_JSON_FILE=""
   RELEASE_ARTIFACT_DIR=""
+  CREATE_RELEASE_TAG="0"
+  PUSH_RELEASE_TAG="0"
+  RUN_RELEASE_VERIFICATION="0"
 
   local dist_tag="latest"
   if [[ "$VERSION" == *-* ]]; then
@@ -353,16 +422,22 @@ main() {
 
   ensure_release_branch_state
 
-  log "running release verification gate"
-  (
-    cd "$ROOT_DIR"
-    pnpm verify:pre-push
-  )
+  if [[ "$RUN_RELEASE_VERIFICATION" == "1" ]]; then
+    log "running release verification gate"
+    (
+      cd "$ROOT_DIR"
+      pnpm verify:pre-push
+    )
+  fi
 
-  log "creating release tag $TAG"
-  git tag -a "$TAG" -m "Release $TAG"
-  log "pushing release tag $TAG"
-  git push origin "refs/tags/$TAG"
+  if [[ "$CREATE_RELEASE_TAG" == "1" ]]; then
+    log "creating release tag $TAG"
+    git tag -a "$TAG" -m "Release $TAG"
+  fi
+  if [[ "$PUSH_RELEASE_TAG" == "1" ]]; then
+    log "pushing release tag $TAG"
+    git push origin "refs/tags/$TAG"
+  fi
 
   log "waiting for GitHub Actions run"
   find_release_run

--- a/scripts/publish_npm_release.test.sh
+++ b/scripts/publish_npm_release.test.sh
@@ -89,10 +89,35 @@ case "$1" in
       exit 0
     fi
     if [[ "$2" == "-q" && "$3" == "--verify" ]]; then
+      if [[ "$4" == refs/tags/* && -n "${MOCK_LOCAL_TAG_SHA:-}" ]]; then
+        printf '%s\n' "$MOCK_LOCAL_TAG_SHA"
+        exit 0
+      fi
       exit 1
     fi
     ;;
+  rev-list)
+    if [[ "$2" == "-n" && "$3" == "1" && -n "${MOCK_LOCAL_TAG_SHA:-}" ]]; then
+      printf '%s\n' "$MOCK_LOCAL_TAG_SHA"
+      exit 0
+    fi
+    ;;
   ls-remote)
+    if [[ -n "${MOCK_REMOTE_TAG_SHA:-}" ]]; then
+      matched=0
+      for arg in "$@"; do
+        if [[ "$arg" == refs/tags/*^{} ]]; then
+          printf '%s\t%s\n' "$MOCK_REMOTE_TAG_SHA" "$arg"
+          matched=1
+        elif [[ "$arg" == refs/tags/* ]]; then
+          printf '%s\t%s\n' "${MOCK_REMOTE_TAG_OBJECT_SHA:-$MOCK_REMOTE_TAG_SHA}" "$arg"
+          matched=1
+        fi
+      done
+      if (( matched == 1 )); then
+        exit 0
+      fi
+    fi
     exit 2
     ;;
   fetch|pull|tag|push)
@@ -438,6 +463,108 @@ run_manual_fallback_test() {
     "olhapi-maestro-1.2.3.tgz"
 }
 
+run_existing_remote_tag_resume_test() {
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/publish-release-test-resume.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  write_mock_commands "$tmp_dir/bin"
+  write_run_list_json "$tmp_dir/run-list.json" 404 failure "v1.2.3-rc.4"
+  write_manual_fallback_run_json "$tmp_dir/run-view.json"
+  create_artifacts "$tmp_dir/artifacts" "1.2.3-rc.4"
+  write_published_state \
+    "$tmp_dir/published.json" \
+    "@olhapi/maestro-darwin-arm64=1.2.3-rc.1"
+
+  PATH="$tmp_dir/bin:$PATH" \
+  MOCK_LOG="$tmp_dir/log.txt" \
+  MOCK_HEAD_SHA="head999" \
+  MOCK_LOCAL_TAG_SHA="tag404" \
+  MOCK_REMOTE_TAG_SHA="tag404" \
+  MOCK_REMOTE_TAG_OBJECT_SHA="obj404" \
+  MOCK_RUN_LIST_JSON="$tmp_dir/run-list.json" \
+  MOCK_RUN_VIEW_JSON="$tmp_dir/run-view.json" \
+  MOCK_PUBLISHED_STATE_FILE="$tmp_dir/published.json" \
+  MOCK_FAIL_ON_REPUBLISH=1 \
+  MOCK_ARTIFACT_SOURCE="$tmp_dir/artifacts" \
+  MOCK_DIST_TAG="next" \
+  MOCK_VERSION="1.2.3-rc.4" \
+  RELEASE_POLL_SEC=0 \
+  RELEASE_RUN_LOOKUP_TIMEOUT_SEC=1 \
+  RELEASE_REGISTRY_TIMEOUT_SEC=1 \
+  "$SCRIPT_UNDER_TEST" "1.2.3-rc.4"
+
+  assert_not_contains "$tmp_dir/log.txt" "pnpm verify:pre-push"
+  assert_not_contains "$tmp_dir/log.txt" "git tag -a v1.2.3-rc.4 -m Release v1.2.3-rc.4"
+  assert_not_contains "$tmp_dir/log.txt" "git push origin refs/tags/v1.2.3-rc.4"
+  assert_contains "$tmp_dir/log.txt" "gh run list --repo olhapi/maestro --workflow release-npm.yml --branch v1.2.3-rc.4 --event push --limit 5 --json databaseId,status,conclusion,url,headBranch"
+  assert_contains "$tmp_dir/log.txt" "gh run download 404 --repo olhapi/maestro --dir"
+}
+
+run_existing_local_tag_push_test() {
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/publish-release-test-local-tag.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  write_mock_commands "$tmp_dir/bin"
+  write_run_list_json "$tmp_dir/run-list.json" 505 success "v1.2.3-rc.5"
+  write_success_run_json "$tmp_dir/run-view.json"
+  write_published_state \
+    "$tmp_dir/published.json" \
+    "@olhapi/maestro-darwin-arm64=1.2.3-rc.5" \
+    "@olhapi/maestro-darwin-x64=1.2.3-rc.5" \
+    "@olhapi/maestro-linux-x64-gnu=1.2.3-rc.5" \
+    "@olhapi/maestro-linux-arm64-gnu=1.2.3-rc.5" \
+    "@olhapi/maestro-win32-x64=1.2.3-rc.5" \
+    "@olhapi/maestro=1.2.3-rc.5"
+
+  PATH="$tmp_dir/bin:$PATH" \
+  MOCK_LOG="$tmp_dir/log.txt" \
+  MOCK_HEAD_SHA="head505" \
+  MOCK_LOCAL_TAG_SHA="head505" \
+  MOCK_RUN_LIST_JSON="$tmp_dir/run-list.json" \
+  MOCK_RUN_VIEW_JSON="$tmp_dir/run-view.json" \
+  MOCK_PUBLISHED_STATE_FILE="$tmp_dir/published.json" \
+  MOCK_DIST_TAG="next" \
+  MOCK_VERSION="1.2.3-rc.5" \
+  RELEASE_POLL_SEC=0 \
+  RELEASE_RUN_LOOKUP_TIMEOUT_SEC=1 \
+  RELEASE_REGISTRY_TIMEOUT_SEC=1 \
+  "$SCRIPT_UNDER_TEST" "1.2.3-rc.5"
+
+  assert_contains "$tmp_dir/log.txt" "pnpm verify:pre-push"
+  assert_not_contains "$tmp_dir/log.txt" "git tag -a v1.2.3-rc.5 -m Release v1.2.3-rc.5"
+  assert_contains "$tmp_dir/log.txt" "git push origin refs/tags/v1.2.3-rc.5"
+}
+
+run_stale_local_tag_guard_test() {
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/publish-release-test-stale-tag.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  write_mock_commands "$tmp_dir/bin"
+  write_run_list_json "$tmp_dir/run-list.json" 606 success "v1.2.3-rc.6"
+  write_success_run_json "$tmp_dir/run-view.json"
+
+  if PATH="$tmp_dir/bin:$PATH" \
+    MOCK_LOG="$tmp_dir/log.txt" \
+    MOCK_HEAD_SHA="head606" \
+    MOCK_LOCAL_TAG_SHA="tag606" \
+    MOCK_RUN_LIST_JSON="$tmp_dir/run-list.json" \
+    MOCK_RUN_VIEW_JSON="$tmp_dir/run-view.json" \
+    MOCK_DIST_TAG="next" \
+    MOCK_VERSION="1.2.3-rc.6" \
+    RELEASE_POLL_SEC=0 \
+    RELEASE_RUN_LOOKUP_TIMEOUT_SEC=1 \
+    RELEASE_REGISTRY_TIMEOUT_SEC=1 \
+    "$SCRIPT_UNDER_TEST" "1.2.3-rc.6"; then
+    fail "stale local tag test should have failed"
+  fi
+
+  assert_not_contains "$tmp_dir/log.txt" "pnpm verify:pre-push"
+  assert_not_contains "$tmp_dir/log.txt" "git push origin refs/tags/v1.2.3-rc.6"
+}
+
 run_dirty_worktree_guard_test() {
   local tmp_dir
   tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/publish-release-test-dirty.XXXXXX")"
@@ -469,4 +596,7 @@ run_success_path_test
 run_double_dash_passthrough_test
 run_tag_specific_run_selection_test
 run_manual_fallback_test
+run_existing_remote_tag_resume_test
+run_existing_local_tag_push_test
+run_stale_local_tag_guard_test
 run_dirty_worktree_guard_test


### PR DESCRIPTION
## Summary
- make the npm release helper resumable when the tag already exists on origin
- keep local-only stale tags guarded while allowing local-at-HEAD tags to be reused
- add release-helper coverage and document the resume path in the runbook

## Testing
- pnpm verify:package
- git push -u origin codex/resume-npm-release-tag (runs pre-push verification)