### PR TITLE
docs(monorepo): clarify Codex MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Maestro is a local-first orchestration runtime for agent-driven software work.
 
+Website: [maestro.olhapi.com](https://maestro.olhapi.com/)
+Repository: [github.com/olhapi/maestro](https://github.com/olhapi/maestro)
+
 It combines a SQLite-backed tracker, an orchestrator that reads `WORKFLOW.md`, a private MCP daemon bridged by `maestro mcp`, and an HTTP server that serves the embedded dashboard plus JSON/WebSocket APIs.
 
 Maestro stays local-first even when a project syncs issues from Linear. Provider-backed issues are synchronized into the local store, then supervised through the same local queue, runtime state, MCP tools, and dashboard surfaces as local kanban issues.
@@ -107,22 +110,17 @@ Issue images are stored next to the active database under `assets/images`. With 
 
 The preview warning on `run` is intentional. Pass `--i-understand-that-this-will-be-running-without-the-usual-guardrails` only when unattended Codex execution is actually what you want.
 
-### 4. Expose the tracker to MCP clients
+### 4. Add the Maestro MCP server to Codex
 
-Add the built or installed binary to your MCP client config:
+If `maestro` is already on your `PATH`, save the MCP entry in Codex once:
 
-```json
-{
-  "mcpServers": {
-    "maestro": {
-      "command": "/absolute/path/to/maestro",
-      "args": ["mcp"]
-    }
-  }
-}
+```bash
+codex mcp add maestro -- maestro mcp
 ```
 
-`maestro mcp` is a stdio bridge into the live `maestro run` daemon for the same database. Start `maestro run` first, then let your MCP client invoke `maestro mcp`.
+If you built Maestro from source and did not add it to your `PATH`, replace `maestro` with the absolute path to the binary.
+
+`maestro mcp` is a stdio bridge into the live `maestro run` daemon for the same database. Start `maestro run` first, then let Codex invoke `maestro mcp`.
 
 ### 5. Open the dashboard or use live CLI helpers
 

--- a/apps/website/src/content/docs/install.mdx
+++ b/apps/website/src/content/docs/install.mdx
@@ -18,6 +18,14 @@ If you are on a supported platform, the published npm package is the fastest pat
 
 The installed command name is still `maestro`.
 
+## Add the MCP server to Codex
+
+Once `maestro` is on your `PATH`, register the shipped MCP bridge with Codex:
+
+<DocsCommandField command={`codex mcp add maestro -- maestro mcp`} />
+
+If you built Maestro from source and the binary is not on your `PATH`, replace `maestro` with the absolute path to the binary you built.
+
 Official npm builds currently cover:
 
 - macOS arm64
@@ -50,7 +58,7 @@ Contributor Docker build:
 
 - Install `go` if you need source builds or local development.
 - Install `codex` before you attempt real orchestration runs that launch the Codex CLI.
-- Use the npm package when you want the shortest path from machine setup to a loop you can start and leave running.
+- Use the npm package when you want the shortest path from machine setup to `codex mcp add maestro -- maestro mcp`.
 
 ## Contributor tooling
 

--- a/apps/website/src/content/docs/quickstart.mdx
+++ b/apps/website/src/content/docs/quickstart.mdx
@@ -20,11 +20,11 @@ This writes a repo-local `WORKFLOW.md` with the default Kanban tracker settings,
 
 ## 2. Expose the tracker to MCP clients
 
-If you installed Maestro from npm, add the shipped `maestro` command to Codex once:
+If `maestro` is already on your `PATH`, add it to Codex once:
 
 <DocsCommandField command={`codex mcp add maestro -- maestro mcp`} />
 
-That uses the npm-installed `maestro` binary already on your `PATH`; you do not need to point Codex at a manually built executable.
+If you built Maestro from source and did not add it to your `PATH`, replace `maestro` with the absolute path to the binary.
 
 `maestro mcp` is a stdio bridge into the live `maestro run` daemon for the same database. Save the entry first, then start the daemon and let Codex attach through it so the agent sees the same queue you will supervise later.
 


### PR DESCRIPTION
## Summary
- clarify the Codex MCP setup instructions in the README
- add the same Codex MCP registration guidance to the install and quickstart docs
- explain the source-build path when `maestro` is not on `PATH`

## Testing
- pnpm verify:website
- pnpm verify:pre-push