### PR TITLE
docs(monorepo): generalize coding agent MCP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,18 +110,24 @@ Issue images are stored next to the active database under `assets/images`. With 
 
 The preview warning on `run` is intentional. Pass `--i-understand-that-this-will-be-running-without-the-usual-guardrails` only when unattended Codex execution is actually what you want.
 
-### 4. Add the Maestro MCP server to Codex or Claude Code
+### 4. Add the Maestro MCP server to your coding agent
 
-If `maestro` is already on your `PATH`, save the MCP entry in your client once:
+Register `maestro mcp` with the MCP setup flow your coding agent provides. Most MCP-capable agents accept a config equivalent to:
 
-```bash
-codex mcp add maestro -- maestro mcp
-claude mcp add maestro -- maestro mcp
+```json
+{
+  "mcpServers": {
+    "maestro": {
+      "command": "maestro",
+      "args": ["mcp"]
+    }
+  }
+}
 ```
 
-If you built Maestro from source and did not add it to your `PATH`, replace `maestro` with the absolute path to the binary in either command. If you want Claude Code to persist the server in a shared project config, use `claude mcp add --scope project maestro -- maestro mcp`.
+If you built Maestro from source and did not add it to your `PATH`, replace `maestro` with the absolute path to the binary.
 
-`maestro mcp` is a stdio bridge into the live `maestro run` daemon for the same database. Start `maestro run` first, then let Codex or Claude Code invoke `maestro mcp`.
+`maestro mcp` is a stdio bridge into the live `maestro run` daemon for the same database. Start `maestro run` first, then let your coding agent invoke `maestro mcp`.
 
 ### 5. Open the dashboard or use live CLI helpers
 

--- a/apps/website/src/content/docs/install.mdx
+++ b/apps/website/src/content/docs/install.mdx
@@ -18,12 +18,20 @@ If you are on a supported platform, the published npm package is the fastest pat
 
 The installed command name is still `maestro`.
 
-## Add the MCP server to Codex or Claude Code
+## Add the MCP server to your coding agent
 
-Once `maestro` is on your `PATH`, register the shipped MCP bridge with your MCP client:
+Once `maestro` is on your `PATH`, register the shipped MCP bridge with the MCP setup flow your coding agent provides. Most MCP-capable agents accept a config equivalent to:
 
-<DocsCommandField command={`codex mcp add maestro -- maestro mcp`} />
-<DocsCommandField command={`claude mcp add maestro -- maestro mcp`} />
+```json
+{
+  "mcpServers": {
+    "maestro": {
+      "command": "maestro",
+      "args": ["mcp"]
+    }
+  }
+}
+```
 
 If you built Maestro from source and the binary is not on your `PATH`, replace `maestro` with the absolute path to the binary you built.
 
@@ -59,8 +67,8 @@ Contributor Docker build:
 
 - Install `go` if you need source builds or local development.
 - Install `codex` before you attempt real orchestration runs that launch the Codex CLI.
-- Install `claude` if you want Claude Code to connect to the local queue through MCP.
-- Use the npm package when you want the shortest path from machine setup to `codex mcp add maestro -- maestro mcp` or `claude mcp add maestro -- maestro mcp`.
+- Install an MCP-capable coding agent if you want to connect to the local queue interactively.
+- Use the npm package when you want the shortest path from machine setup to a local `maestro mcp` registration.
 
 ## Contributor tooling
 

--- a/apps/website/src/content/docs/quickstart.mdx
+++ b/apps/website/src/content/docs/quickstart.mdx
@@ -8,7 +8,7 @@ navLabel: Quickstart
 
 import DocsCommandField from "./_components/DocsCommandField.astro";
 
-Quickstart is the shortest path to a safe handoff. You will write the repo contract, expose the live queue to Codex or Claude Code, start the daemon, and see where to check back in once the loop is running.
+Quickstart is the shortest path to a safe handoff. You will write the repo contract, expose the live queue to a coding agent, start the daemon, and see where to check back in once the loop is running.
 
 ## 1. Initialize a workflow file
 
@@ -20,12 +20,20 @@ This writes a repo-local `WORKFLOW.md` with the default Kanban tracker settings,
 
 ## 2. Expose the tracker to MCP clients
 
-If `maestro` is already on your `PATH`, add it to Codex or Claude Code once:
+If `maestro` is already on your `PATH`, register it with the MCP setup flow your coding agent provides. Most MCP-capable agents accept a config equivalent to:
 
-<DocsCommandField command={`codex mcp add maestro -- maestro mcp`} />
-<DocsCommandField command={`claude mcp add maestro -- maestro mcp`} />
+```json
+{
+  "mcpServers": {
+    "maestro": {
+      "command": "maestro",
+      "args": ["mcp"]
+    }
+  }
+}
+```
 
-If you built Maestro from source and did not add it to your `PATH`, replace `maestro` with the absolute path to the binary. If you want Claude Code to persist the server into a shared project config, add `--scope project` before `maestro`.
+If you built Maestro from source and did not add it to your `PATH`, replace `maestro` with the absolute path to the binary.
 
 `maestro mcp` is a stdio bridge into the live `maestro run` daemon for the same database. Save the entry first, then start the daemon and let your MCP client attach through it so the agent sees the same queue you will supervise later.
 
@@ -49,18 +57,18 @@ This is the handoff point. Once the daemon is running, Maestro keeps doing the r
 
 When you want to check progress, use the control center or the live CLI helpers instead of reconstructing state from scratch.
 
-## 4. Create a first queue from an MCP client
+## 4. Create a first queue from your coding agent
 
 This seeds the same queue you will supervise from the dashboard once real work is in flight.
 
-With the daemon running, ask your client to seed the tracker through the saved `maestro` MCP server. For example, from Codex:
+With the daemon running, ask your coding agent to seed the tracker through the saved `maestro` MCP server. For example:
 
-<DocsCommandField
-  command={`codex --cd /path/to/todo-app "Use the maestro MCP server to create a project, epics, and issues for a new react todo app. Set the project repo path to the current working directory. Plan the features first, split them into epics, add a priority value and blockers for each issue, set their state to ready."`}
-/>
+```text
+Use the maestro MCP server to create a project, epics, and issues for a new react todo app. Set the project repo path to the current working directory. Plan the features first, split them into epics, add a priority value and blockers for each issue, set their state to ready.
+```
 
 This example assumes the default local `kanban` provider, which supports epics, issue priorities, and blockers.
-The same prompt works in Claude Code once the `maestro` MCP server is saved there.
+The same prompt works in any connected coding agent once the `maestro` MCP server is saved there.
 
 ## 5. Open the control center when you want to step back in
 


### PR DESCRIPTION
## Summary
- generalize the MCP setup docs so they refer to a coding agent instead of specific clients
- document `maestro mcp` using a generic MCP config shape that can work across supported tools
- make the quickstart queue-seeding example tool-agnostic

## Verification
- pnpm run website:check
- git commit hook: pnpm verify:website
- branch push completed from a clean worktree because the primary checkout had unrelated local modifications
