### PR TITLE
feat(monorepo): include project descriptions in codex prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,15 @@ This writes a repo-local `WORKFLOW.md` with the default orchestration settings a
 ### 2. Create a project and queue some work
 
 ```bash
-maestro project create "My App" --repo /absolute/path/to/my-app --desc "Example project"
+maestro project create "My App" --repo /absolute/path/to/my-app --desc "Repo-wide Codex guidance: use pnpm, keep changes scoped, and run focused validation for touched packages."
 maestro issue create "Add login page" --project <project_id> --labels feature,ui
 maestro issue create "Fix auth bug" --project <project_id> --priority 1 --labels bug
 maestro issue move ISS-1 ready
 ```
 
 Projects default to the local `kanban` provider. You can also register a project with limited Linear-backed sync by passing `--provider linear --provider-project-ref <slug>` and, if needed, `--provider-endpoint` or `--provider-assignee`.
+
+Project descriptions are not just dashboard notes. Maestro passes `project.description` into every implementation, review, and done prompt by default, so use it for standing requirements, conventions, and validation expectations Codex should keep in mind for every issue.
 
 ### 3. Start the daemon
 
@@ -255,8 +257,13 @@ Supported prompt-template variables are:
 - `{{ issue.title }}`
 - `{{ issue.description }}`
 - `{{ issue.state }}`
+- `{{ project.id }}`
+- `{{ project.name }}`
+- `{{ project.description }}`
 - `{{ phase }}`
 - `{{ attempt }}`
+
+When a project has a description, Maestro's default implementation, review, and done prompts include it automatically under a `Project context:` section. Custom workflows can place `{{ project.description }}` wherever they want.
 
 The checked-in [`WORKFLOW.md`](WORKFLOW.md) is this repository's own workflow example. It is not guaranteed to match fresh `workflow init` defaults exactly.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -41,9 +41,13 @@ phases:
     # Enable a dedicated review pass after implementation. Other option: false.
     enabled: false
     # Prompt rendered when the issue enters review. Uses the same template variables
-    # as the main prompt, such as issue.*, phase, and attempt.
+    # as the main prompt, such as issue.*, project.*, phase, and attempt.
     prompt: |
       Review the implementation for issue {{ issue.identifier }} in the current workspace.
+      {% if project.description %}
+      Project context:
+      {{ project.description }}
+      {% endif %}
       Run focused verification, fix any issues you find, move the issue back to in_progress if more work is needed, and move it to done when review is complete.
   done:
     # Enable a dedicated finalization pass after implementation is otherwise complete.
@@ -51,6 +55,10 @@ phases:
     # Prompt rendered when the issue enters done for project-specific wrap-up steps.
     prompt: |
       Finalize issue {{ issue.identifier }} from the current workspace.
+      {% if project.description %}
+      Project context:
+      {{ project.description }}
+      {% endif %}
       Perform the project-specific done steps, such as opening or updating a PR, merging, or other release bookkeeping, while keeping the issue in done unless it truly needs to be reopened.
 
 # Agent runtime settings.
@@ -113,6 +121,11 @@ Continuation attempt: {{ attempt }}
 
 Title: {{ issue.title }}
 State: {{ issue.state }}
+{% if project.description %}
+Project context:
+{{ project.description }}
+
+{% endif %}
 Description:
 {% if issue.description %}
 {{ issue.description }}

--- a/apps/website/src/content/docs/cli-reference.mdx
+++ b/apps/website/src/content/docs/cli-reference.mdx
@@ -22,6 +22,8 @@ maestro project delete <id>`}
 
 Use project commands to register a repo, inspect the local tracker, configure project-level providers, and remove stale projects from the store.
 
+Use `--desc` for durable Codex guidance, not just a label. Maestro includes `project.description` in the default implementation, review, and done prompts for every issue in that project.
+
 `start` and `stop` are live control commands. They require `--api-url` because they talk to a running Maestro daemon over HTTP.
 
 `kanban` is the default provider. `linear` support exists, but it is intentionally limited and does not support epics.

--- a/apps/website/src/content/docs/quickstart.mdx
+++ b/apps/website/src/content/docs/quickstart.mdx
@@ -18,6 +18,8 @@ Start in the repo you want Maestro to orchestrate:
 
 This writes a repo-local `WORKFLOW.md` with the default Kanban tracker settings, Codex command, and prompt template. It is the contract Maestro will keep following while you are elsewhere.
 
+When you create a project later, treat its description as durable agent guidance rather than a short label. Maestro passes that project description into every issue prompt by default.
+
 ## 2. Expose the tracker to MCP clients
 
 If `maestro` is already on your `PATH`, register it with the MCP setup flow your coding agent provides. Most MCP-capable agents accept a config equivalent to:
@@ -69,6 +71,8 @@ Use the maestro MCP server to create a project, epics, and issues for a new reac
 
 This example assumes the default local `kanban` provider, which supports epics, issue priorities, and blockers.
 The same prompt works in any connected coding agent once the `maestro` MCP server is saved there.
+
+Project descriptions are the right place for repo-wide instructions such as required test commands, package-manager expectations, or rules about keeping public APIs stable. That text becomes `{{ project.description }}` in the workflow template and is included in Maestro's default prompts automatically.
 
 ## 5. Open the control center when you want to step back in
 

--- a/apps/website/src/content/docs/workflow-config.mdx
+++ b/apps/website/src/content/docs/workflow-config.mdx
@@ -68,8 +68,13 @@ The issue prompt template can interpolate:
 - `{{ issue.title }}`
 - `{{ issue.description }}`
 - `{{ issue.state }}`
+- `{{ project.id }}`
+- `{{ project.name }}`
+- `{{ project.description }}`
 - `{{ phase }}`
 - `{{ attempt }}`
+
+If a project has a description, Maestro's default implementation, review, and done prompts automatically add it as a `Project context:` section. Use project descriptions for standing guidance that should apply across every issue in that project, and use custom workflow templates when you want to move `{{ project.description }}` elsewhere.
 
 ## Bootstrap behavior
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -514,6 +514,10 @@ Continuation guidance:
 	if !phase.IsValid() {
 		phase = kanban.DefaultWorkflowPhaseForState(issue.State)
 	}
+	projectCtx, err := r.projectPromptContext(issue.ProjectID)
+	if err != nil {
+		return preparedTurnPrompt{}, err
+	}
 	ctx := map[string]interface{}{
 		"issue": map[string]interface{}{
 			"id":          issue.ID,
@@ -529,6 +533,7 @@ Continuation guidance:
 			"created_at":  issue.CreatedAt.Format(time.RFC3339),
 			"updated_at":  issue.UpdatedAt.Format(time.RFC3339),
 		},
+		"project": projectCtx,
 		"attempt": nil,
 		"phase":   string(phase),
 	}
@@ -555,6 +560,28 @@ Continuation guidance:
 		Prompt:   rendered + "\n\n" + strings.TrimSpace(firstTurnExecutionGuidance),
 		Commands: commands,
 	}, nil
+}
+
+func (r *Runner) projectPromptContext(projectID string) (map[string]interface{}, error) {
+	ctx := map[string]interface{}{
+		"id":          "",
+		"name":        "",
+		"description": "",
+	}
+	if strings.TrimSpace(projectID) == "" {
+		return ctx, nil
+	}
+	project, err := r.store.GetProject(projectID)
+	if err != nil {
+		if kanban.IsNotFound(err) {
+			return ctx, nil
+		}
+		return nil, err
+	}
+	ctx["id"] = project.ID
+	ctx["name"] = project.Name
+	ctx["description"] = project.Description
+	return ctx, nil
 }
 
 func promptTemplateForPhase(workflow *config.Workflow, phase kanban.WorkflowPhase) string {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -83,6 +83,22 @@ func sampleRunnerPNGBytes() []byte {
 	}
 }
 
+func defaultPromptWorkflowForTest() *config.Workflow {
+	cfg := config.DefaultConfig()
+	cfg.Phases.Review = config.PhasePromptConfig{
+		Enabled: true,
+		Prompt:  config.DefaultReviewPromptTemplate(),
+	}
+	cfg.Phases.Done = config.PhasePromptConfig{
+		Enabled: true,
+		Prompt:  config.DefaultDonePromptTemplate(),
+	}
+	return &config.Workflow{
+		Config:         cfg,
+		PromptTemplate: config.DefaultPromptTemplate(),
+	}
+}
+
 func baseRunnerAppServerScenario(threadID, turnID string, afterTurnStart ...fakeappserver.Output) fakeappserver.Scenario {
 	return fakeappserver.Scenario{
 		Steps: []fakeappserver.Step{
@@ -146,6 +162,159 @@ func TestBuildTurnPrompt(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Prefer deterministic local verification first") {
 		t.Fatalf("expected execution guidance in prompt, got %q", prompt)
+	}
+}
+
+func TestBuildTurnPromptIncludesProjectContextInDefaultImplementationPrompt(t *testing.T) {
+	runner, store, _, _, repoPath := setupTestRunner(t, "cat", config.AgentModeStdio)
+	workflow := defaultPromptWorkflowForTest()
+
+	project, err := store.CreateProject("Platform", "Use pnpm in this repo and run focused validation for touched packages.", repoPath, "")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	issue, err := store.CreateIssue(project.ID, "", "Fix Login Bug", "Users cannot log in", 1, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	prompt, err := runner.buildTurnPrompt(workflow, issue, 0, 1)
+	if err != nil {
+		t.Fatalf("buildTurnPrompt: %v", err)
+	}
+	if !strings.Contains(prompt, "Project context:\nUse pnpm in this repo and run focused validation for touched packages.") {
+		t.Fatalf("expected project context in prompt, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "Description:") || !strings.Contains(prompt, "Users cannot log in") {
+		t.Fatalf("expected issue description in prompt, got %q", prompt)
+	}
+}
+
+func TestBuildTurnPromptIncludesProjectContextInDefaultPhasePrompts(t *testing.T) {
+	runner, store, _, _, repoPath := setupTestRunner(t, "cat", config.AgentModeStdio)
+	workflow := defaultPromptWorkflowForTest()
+
+	project, err := store.CreateProject("Platform", "Always preserve the public API unless the issue explicitly allows a breaking change.", repoPath, "")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	issue, err := store.CreateIssue(project.ID, "", "Ship the change", "Issue details", 1, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		phase kanban.WorkflowPhase
+		want  string
+	}{
+		{name: "review", phase: kanban.WorkflowPhaseReview, want: "You are performing the review pass"},
+		{name: "done", phase: kanban.WorkflowPhaseDone, want: "You are performing the done pass"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issueCopy := *issue
+			issueCopy.WorkflowPhase = tc.phase
+
+			prompt, err := runner.buildTurnPrompt(workflow, &issueCopy, 0, 1)
+			if err != nil {
+				t.Fatalf("buildTurnPrompt: %v", err)
+			}
+			if !strings.Contains(prompt, tc.want) {
+				t.Fatalf("expected phase heading %q, got %q", tc.want, prompt)
+			}
+			if !strings.Contains(prompt, "Project context:\nAlways preserve the public API unless the issue explicitly allows a breaking change.") {
+				t.Fatalf("expected project context in %s prompt, got %q", tc.phase, prompt)
+			}
+		})
+	}
+}
+
+func TestBuildTurnPromptRendersProjectVariablesInCustomWorkflow(t *testing.T) {
+	runner, store, _, _, repoPath := setupTestRunner(t, "cat", config.AgentModeStdio)
+	workflow := &config.Workflow{
+		Config:         config.DefaultConfig(),
+		PromptTemplate: "Project={{ project.name }}|{{ project.description }}\nIssue={{ issue.identifier }}",
+	}
+
+	project, err := store.CreateProject("Platform", "Ship focused changes.", repoPath, "")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	issueWithProject, err := store.CreateIssue(project.ID, "", "Custom prompt", "", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue with project: %v", err)
+	}
+	issueWithMissingProject, err := store.CreateIssue("", "", "Missing project", "", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue missing project: %v", err)
+	}
+	issueWithMissingProject.ProjectID = "proj-missing"
+
+	cases := []struct {
+		name  string
+		issue *kanban.Issue
+		want  string
+	}{
+		{name: "present", issue: issueWithProject, want: "Project=Platform|Ship focused changes."},
+		{name: "missing", issue: issueWithMissingProject, want: "Project=|"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt, err := runner.buildTurnPrompt(workflow, tc.issue, 0, 1)
+			if err != nil {
+				t.Fatalf("buildTurnPrompt: %v", err)
+			}
+			if !strings.Contains(prompt, tc.want) {
+				t.Fatalf("expected prompt to contain %q, got %q", tc.want, prompt)
+			}
+		})
+	}
+}
+
+func TestBuildTurnPromptOmitsProjectContextWhenUnavailable(t *testing.T) {
+	runner, store, _, _, repoPath := setupTestRunner(t, "cat", config.AgentModeStdio)
+	workflow := defaultPromptWorkflowForTest()
+
+	issueWithoutProject, err := store.CreateIssue("", "", "No project", "Issue details", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue without project: %v", err)
+	}
+	projectWithoutDescription, err := store.CreateProject("Platform", "", repoPath, "")
+	if err != nil {
+		t.Fatalf("CreateProject empty description: %v", err)
+	}
+	issueWithoutProjectDescription, err := store.CreateIssue(projectWithoutDescription.ID, "", "Empty project description", "Issue details", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue empty description: %v", err)
+	}
+	issueWithMissingProject, err := store.CreateIssue("", "", "Missing project", "Issue details", 0, nil)
+	if err != nil {
+		t.Fatalf("CreateIssue missing project: %v", err)
+	}
+	issueWithMissingProject.ProjectID = "proj-missing"
+
+	cases := []struct {
+		name  string
+		issue *kanban.Issue
+	}{
+		{name: "no_project", issue: issueWithoutProject},
+		{name: "empty_description", issue: issueWithoutProjectDescription},
+		{name: "missing_project", issue: issueWithMissingProject},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt, err := runner.buildTurnPrompt(workflow, tc.issue, 0, 1)
+			if err != nil {
+				t.Fatalf("buildTurnPrompt: %v", err)
+			}
+			if strings.Contains(prompt, "Project context:") {
+				t.Fatalf("expected prompt to omit project context, got %q", prompt)
+			}
+		})
 	}
 }
 

--- a/internal/speccheck/check.go
+++ b/internal/speccheck/check.go
@@ -62,6 +62,11 @@ func Run(repoRoot string) Report {
 				"description": "Parses correctly",
 				"state":       "ready",
 			},
+			"project": map[string]interface{}{
+				"id":          "PRJ-1",
+				"name":        "Spec check project",
+				"description": "Follow repo-wide guidance",
+			},
 			"phase":   "implementation",
 			"attempt": 1,
 		}); err != nil {

--- a/internal/speccheck/check_test.go
+++ b/internal/speccheck/check_test.go
@@ -34,6 +34,9 @@ tracker:
 {{ issue.title }}
 {{ issue.description }}
 {{ issue.state }}
+{{ project.id }}
+{{ project.name }}
+{{ project.description }}
 {{ phase }}
 {{ attempt }}
 `

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -162,6 +162,11 @@ Continuation attempt: {{ attempt }}
 {% endif %}
 
 Title: {{ issue.title }}
+{% if project.description %}
+Project context:
+{{ project.description }}
+
+{% endif %}
 Description:
 {% if issue.description %}
 {{ issue.description }}
@@ -177,6 +182,11 @@ You are performing the review pass for issue {{ issue.identifier }}.
 
 Title: {{ issue.title }}
 State: {{ issue.state }}
+{% if project.description %}
+Project context:
+{{ project.description }}
+
+{% endif %}
 Description:
 {% if issue.description %}
 {{ issue.description }}
@@ -194,6 +204,11 @@ Review the implementation in the current workspace, run focused verification, an
 func DefaultInitReviewPromptTemplate() string {
 	return strings.TrimSpace(`
 Review the implementation for issue {{ issue.identifier }} in the current workspace.
+{% if project.description %}
+Project context:
+{{ project.description }}
+
+{% endif %}
 Run focused verification, fix any issues you find, move the issue back to in_progress if more work is needed, and move it to done when review is complete.
 `)
 }
@@ -204,6 +219,11 @@ You are performing the done pass for issue {{ issue.identifier }}.
 
 Title: {{ issue.title }}
 State: {{ issue.state }}
+{% if project.description %}
+Project context:
+{{ project.description }}
+
+{% endif %}
 Description:
 {% if issue.description %}
 {{ issue.description }}
@@ -220,6 +240,11 @@ The implementation is already complete. Perform the project-specific finalizatio
 func DefaultInitDonePromptTemplate() string {
 	return strings.TrimSpace(`
 Finalize issue {{ issue.identifier }} from the current workspace.
+{% if project.description %}
+Project context:
+{{ project.description }}
+
+{% endif %}
 Perform the project-specific done steps, such as opening or updating a PR, merging, or other release bookkeeping, while keeping the issue in done unless it truly needs to be reopened.
 `)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -425,7 +425,7 @@ func TestInitWorkflowWritesExpectedFile(t *testing.T) {
 		"timeout_ms: 60000",
 		"phases:",
 		"enabled: false",
-		"issue.*, phase, and attempt",
+		"issue.*, project.*, phase, and attempt",
 		"max_concurrent_agents: 3",
 		"max_turns: 4",
 		"max_retry_backoff_ms: 60000",

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -375,7 +375,7 @@ phases:
     # Enable a dedicated review pass after implementation. Other option: false.
     enabled: false
     # Prompt rendered when the issue enters review. Uses the same template variables
-    # as the main prompt, such as issue.*, phase, and attempt.
+    # as the main prompt, such as issue.*, project.*, phase, and attempt.
     prompt: |
 %s
   done:


### PR DESCRIPTION
## Summary
- add `project.*` prompt context to issue prompt rendering with safe fallback when project data is missing
- include project descriptions in the default implementation, review, and done prompts
- document project descriptions as durable Codex guidance in the README, workflow example, and docs site

## Testing
- go test ./internal/agent ./internal/speccheck ./pkg/config
- pnpm website:check
- pnpm website:test
- repo pre-commit and pre-push hooks (including verify:pre-push and retry-safety e2e)