### PR TITLE
[codex] fix(frontend): reflow issue detail layout

### DIFF
--- a/apps/frontend/src/routes/issue-detail.test.tsx
+++ b/apps/frontend/src/routes/issue-detail.test.tsx
@@ -1246,7 +1246,7 @@ describe("IssueDetailPage", () => {
     });
   });
 
-  it("keeps the composer in the rail and renders command history in the main column", async () => {
+  it("keeps the composer with the issue actions and renders execution triage below the main content", async () => {
     const bootstrap = makeBootstrapResponse();
     const issue = makeIssueDetail({ state: "done" });
     vi.mocked(api.bootstrap).mockResolvedValue(bootstrap);
@@ -1315,15 +1315,18 @@ describe("IssueDetailPage", () => {
     });
 
     const mainColumn = screen.getByTestId("issue-main-column");
-    const controlRail = screen.getByTestId("issue-control-rail");
+    const managementSection = screen.getByTestId("issue-management-section");
+    const executionTriage = screen.getByText("Execution triage");
 
-    expect(within(mainColumn).getByText("Execution triage")).toBeInTheDocument();
+    expect(within(mainColumn).queryByText("Execution triage")).not.toBeInTheDocument();
     expect(within(mainColumn).queryByText("Command history")).not.toBeInTheDocument();
-    expect(within(controlRail).getByText("Issue actions")).toBeInTheDocument();
-    expect(within(controlRail).getByText("Agent commands")).toBeInTheDocument();
+    expect(within(managementSection).getByText("Issue actions")).toBeInTheDocument();
+    expect(within(managementSection).getByText("Agent commands")).toBeInTheDocument();
     expect(screen.queryByText("Command history")).not.toBeInTheDocument();
-    expect(within(controlRail).queryByText("Latest command")).not.toBeInTheDocument();
-    expect(within(controlRail).queryByText("Follow-up command")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("issue-control-rail")).not.toBeInTheDocument();
+    expect(mainColumn.compareDocumentPosition(executionTriage) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
 
     fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
       target: { value: "Merge the branch to master." },
@@ -1339,13 +1342,10 @@ describe("IssueDetailPage", () => {
     });
 
     await waitFor(() => {
-      expect(
-        within(controlRail).getByText("Waiting for unblock"),
-      ).toBeInTheDocument();
+      expect(within(managementSection).getByText("Waiting for unblock")).toBeInTheDocument();
     });
-    expect(within(mainColumn).queryByText("Merge the branch to master.")).not.toBeInTheDocument();
     expect(
-      within(controlRail).getByText("Merge the branch to master."),
+      within(managementSection).getByText("Merge the branch to master."),
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId("agent-command-cmd-1")).getByRole("button", { name: /edit command/i }),
@@ -1732,7 +1732,7 @@ describe("IssueDetailPage", () => {
     });
   });
 
-  it("keeps the state selector under issue actions and removes the extra control cards", async () => {
+  it("keeps the state selector with issue actions", async () => {
     const bootstrap = makeBootstrapResponse();
     const issue = makeIssueDetail({ state: "backlog" });
     vi.mocked(api.bootstrap).mockResolvedValue(bootstrap);
@@ -1761,9 +1761,9 @@ describe("IssueDetailPage", () => {
       expect(screen.getByText("Issue actions")).toBeInTheDocument();
     });
 
-    const controlRail = screen.getByTestId("issue-control-rail");
-    expect(within(controlRail).queryByText("Live adjustments")).not.toBeInTheDocument();
-    expect(within(controlRail).queryByText("Blockers")).not.toBeInTheDocument();
+    const managementSection = screen.getByTestId("issue-management-section");
+    expect(within(managementSection).getByRole("combobox", { name: /issue state/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("issue-control-rail")).not.toBeInTheDocument();
 
     await selectOption(/issue state/i, /ready/i);
 

--- a/apps/frontend/src/routes/issue-detail.tsx
+++ b/apps/frontend/src/routes/issue-detail.tsx
@@ -1151,7 +1151,7 @@ export function IssueDetailPage() {
         </div>
       ) : null}
 
-      <div className="grid items-start gap-[var(--section-gap)] xl:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="grid gap-[var(--section-gap)]">
         <div className="grid min-w-0 gap-[var(--section-gap)]" data-testid="issue-main-column">
           <Card>
             <CardContent className="grid gap-3 pt-[var(--panel-padding)] sm:grid-cols-2 xl:grid-cols-3">
@@ -1373,180 +1373,180 @@ export function IssueDetailPage() {
             </CardContent>
           </Card>
 
-          <SessionExecutionCard
-            approvingPlan={planApprovalResponseMutation.isPending}
-            continuing={retryMutation.isPending}
-            execution={execution.data}
-            issueTotalTokens={issue.data.total_tokens_spent}
-            onApprovePlan={(note) => {
-              planApprovalResponseMutation.mutate({ approved: true, note });
-            }}
-            onContinue={() => {
-              retryMutation.mutate();
-            }}
-            onRequestPlanRevision={(note) => {
-              planApprovalResponseMutation.mutate({ approved: false, note });
-            }}
-          />
-        </div>
-
-        <div className="grid content-start gap-[var(--section-gap)]" data-testid="issue-control-rail">
-          <Card>
-            <CardHeader>
-              <CardTitle>Issue actions</CardTitle>
-            </CardHeader>
-            <CardContent className="grid gap-2.5">
-              <Select
-                value={issue.data.state}
-                disabled={stateMutation.isPending}
-                onValueChange={(value) => {
-                  stateMutation.mutate(value as IssueState);
-                }}
-              >
-                <SelectTrigger aria-label="Issue state">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableStates.map((value) => (
-                    <SelectItem key={value} value={value}>
-                      {getStateMeta(value).label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <div className="grid gap-2">
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">Agent permissions</p>
+          <div className="grid gap-[var(--section-gap)]" data-testid="issue-management-section">
+            <Card>
+              <CardHeader>
+                <CardTitle>Issue actions</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-2.5">
                 <Select
-                  value={issue.data.permission_profile ?? "default"}
-                  onValueChange={async (value) => {
-                    await permissionMutation.mutateAsync(value as PermissionProfile);
+                  value={issue.data.state}
+                  disabled={stateMutation.isPending}
+                  onValueChange={(value) => {
+                    stateMutation.mutate(value as IssueState);
                   }}
                 >
-                  <SelectTrigger aria-label="Agent permissions" disabled={permissionMutation.isPending}>
+                  <SelectTrigger aria-label="Issue state">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="default">{permissionProfileLabels.default}</SelectItem>
-                    <SelectItem value="full-access">{permissionProfileLabels["full-access"]}</SelectItem>
-                    <SelectItem value="plan-then-full-access">{permissionProfileLabels["plan-then-full-access"]}</SelectItem>
+                    {availableStates.map((value) => (
+                      <SelectItem key={value} value={value}>
+                        {getStateMeta(value).label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
-                <p className="text-xs text-[var(--muted-foreground)]">
-                  {permissionProfileHelpText(issue.data.permission_profile, issue.data.project_permission_profile)}
-                </p>
-              </div>
-              <div className="grid grid-cols-3 gap-2.5" data-testid="issue-actions-row">
-                <Button
-                  variant="secondary"
-                  size="icon"
-                  className="h-12 w-full"
-                  onClick={() => setEditOpen(true)}
-                  aria-label="Edit issue"
-                  title="Edit issue"
-                >
-                  <Pencil className="size-4" />
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="icon"
-                  className="h-12 w-full"
-                  onClick={() => retryMutation.mutate()}
-                  disabled={retryMutation.isPending}
-                  aria-label={retryActionLabel}
-                  title={retryActionLabel}
-                >
-                  <RotateCcw className="size-4" />
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="icon"
-                  className="h-12 w-full"
-                  onClick={() => setDeleteConfirmOpen(true)}
-                  disabled={deleteMutation.isPending}
-                  aria-label="Delete"
-                  title="Delete"
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              </div>
-              {issue.data.issue_type === "recurring" ? (
-                <Button variant="secondary" onClick={() => runNowMutation.mutate()} disabled={runNowMutation.isPending}>
-                  <RotateCcw className="size-4" />
-                  Run now
-                </Button>
-              ) : null}
-            </CardContent>
-          </Card>
+                <div className="grid gap-2">
+                  <p className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">Agent permissions</p>
+                  <Select
+                    value={issue.data.permission_profile ?? "default"}
+                    onValueChange={async (value) => {
+                      await permissionMutation.mutateAsync(value as PermissionProfile);
+                    }}
+                  >
+                    <SelectTrigger aria-label="Agent permissions" disabled={permissionMutation.isPending}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="default">{permissionProfileLabels.default}</SelectItem>
+                      <SelectItem value="full-access">{permissionProfileLabels["full-access"]}</SelectItem>
+                      <SelectItem value="plan-then-full-access">{permissionProfileLabels["plan-then-full-access"]}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-[var(--muted-foreground)]">
+                    {permissionProfileHelpText(issue.data.permission_profile, issue.data.project_permission_profile)}
+                  </p>
+                </div>
+                <div className="grid grid-cols-3 gap-2.5" data-testid="issue-actions-row">
+                  <Button
+                    variant="secondary"
+                    size="icon"
+                    className="h-12 w-full"
+                    onClick={() => setEditOpen(true)}
+                    aria-label="Edit issue"
+                    title="Edit issue"
+                  >
+                    <Pencil className="size-4" />
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="icon"
+                    className="h-12 w-full"
+                    onClick={() => retryMutation.mutate()}
+                    disabled={retryMutation.isPending}
+                    aria-label={retryActionLabel}
+                    title={retryActionLabel}
+                  >
+                    <RotateCcw className="size-4" />
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="icon"
+                    className="h-12 w-full"
+                    onClick={() => setDeleteConfirmOpen(true)}
+                    disabled={deleteMutation.isPending}
+                    aria-label="Delete"
+                    title="Delete"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+                {issue.data.issue_type === "recurring" ? (
+                  <Button variant="secondary" onClick={() => runNowMutation.mutate()} disabled={runNowMutation.isPending}>
+                    <RotateCcw className="size-4" />
+                    Run now
+                  </Button>
+                ) : null}
+              </CardContent>
+            </Card>
 
-          <Card>
-            <CardHeader className="pb-2.5">
-              <div className="flex items-center justify-between gap-3">
-                <CardTitle>Agent commands</CardTitle>
-                <span className="text-xs text-[var(--muted-foreground)]">
-                  {agentCommands.length} total
-                </span>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4 pt-0">
-              <div className="relative">
-                <Textarea
-                  value={commandDraft}
-                  onChange={(event) => setCommandDraft(event.target.value)}
-                  className="min-h-[140px] resize-none pb-16 pr-16"
-                  placeholder="Tell the agent what it missed or what it should do next."
-                  onKeyDown={(event) => {
-                    handleAgentCommandTextAreaKeyDown(event, commandDraft.trim().length > 0 && !commandMutation.isPending, () => {
-                      commandMutation.mutate(commandDraft.trim());
-                    });
-                  }}
-                />
-                <Button
-                  type="button"
-                  size="icon"
-                  className="absolute bottom-4 right-3"
-                  onClick={() => commandMutation.mutate(commandDraft.trim())}
-                  disabled={!commandDraft.trim() || commandMutation.isPending}
-                  aria-label="Send to agent"
-                  title="Send to agent"
-                >
-                  <Send className="size-4 shrink-0" />
-                </Button>
-              </div>
-              <div className="space-y-2.5 border-t border-white/8 pt-4">
-                {agentCommands.length === 0 ? (
-                  <p className="text-sm text-[var(--muted-foreground)]">No follow-up commands sent yet.</p>
-                ) : (
-                  agentCommands.map((command) => (
-                    <AgentCommandEntry
-                      key={command.id}
-                      command={command}
-                      editingCommandID={editingCommandID}
-                      onCancelEdit={() => setEditingCommandID(null)}
-                      onSaveEdit={async (commandID, body) => {
-                        await updateCommandMutation.mutateAsync({ commandID, command: body });
-                      }}
-                      onStartDelete={(targetCommand) => {
-                        setEditingCommandID(null);
-                        setDeleteCommandTarget(targetCommand);
-                      }}
-                      onStartEdit={(targetCommand) => {
-                        setDeleteCommandTarget(null);
-                        setEditingCommandID(targetCommand.id);
-                      }}
-                      onStartSteer={(targetCommand) => {
-                        setDeleteCommandTarget(null);
-                        setEditingCommandID(null);
-                        steerCommandMutation.mutate({ commandID: targetCommand.id });
-                      }}
-                      steerPending={steerCommandMutation.isPending}
-                      updatePending={updateCommandMutation.isPending}
-                    />
-                  ))
-                )}
-              </div>
-            </CardContent>
-          </Card>
+            <Card>
+              <CardHeader className="pb-2.5">
+                <div className="flex items-center justify-between gap-3">
+                  <CardTitle>Agent commands</CardTitle>
+                  <span className="text-xs text-[var(--muted-foreground)]">
+                    {agentCommands.length} total
+                  </span>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4 pt-0">
+                <div className="relative">
+                  <Textarea
+                    value={commandDraft}
+                    onChange={(event) => setCommandDraft(event.target.value)}
+                    className="min-h-[140px] resize-none pb-16 pr-16"
+                    placeholder="Tell the agent what it missed or what it should do next."
+                    onKeyDown={(event) => {
+                      handleAgentCommandTextAreaKeyDown(event, commandDraft.trim().length > 0 && !commandMutation.isPending, () => {
+                        commandMutation.mutate(commandDraft.trim());
+                      });
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    size="icon"
+                    className="absolute bottom-4 right-3"
+                    onClick={() => commandMutation.mutate(commandDraft.trim())}
+                    disabled={!commandDraft.trim() || commandMutation.isPending}
+                    aria-label="Send to agent"
+                    title="Send to agent"
+                  >
+                    <Send className="size-4 shrink-0" />
+                  </Button>
+                </div>
+                <div className="space-y-2.5 border-t border-white/8 pt-4">
+                  {agentCommands.length === 0 ? (
+                    <p className="text-sm text-[var(--muted-foreground)]">No follow-up commands sent yet.</p>
+                  ) : (
+                    agentCommands.map((command) => (
+                      <AgentCommandEntry
+                        key={command.id}
+                        command={command}
+                        editingCommandID={editingCommandID}
+                        onCancelEdit={() => setEditingCommandID(null)}
+                        onSaveEdit={async (commandID, body) => {
+                          await updateCommandMutation.mutateAsync({ commandID, command: body });
+                        }}
+                        onStartDelete={(targetCommand) => {
+                          setEditingCommandID(null);
+                          setDeleteCommandTarget(targetCommand);
+                        }}
+                        onStartEdit={(targetCommand) => {
+                          setDeleteCommandTarget(null);
+                          setEditingCommandID(targetCommand.id);
+                        }}
+                        onStartSteer={(targetCommand) => {
+                          setDeleteCommandTarget(null);
+                          setEditingCommandID(null);
+                          steerCommandMutation.mutate({ commandID: targetCommand.id });
+                        }}
+                        steerPending={steerCommandMutation.isPending}
+                        updatePending={updateCommandMutation.isPending}
+                      />
+                    ))
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
         </div>
+
+        <SessionExecutionCard
+          approvingPlan={planApprovalResponseMutation.isPending}
+          continuing={retryMutation.isPending}
+          execution={execution.data}
+          issueTotalTokens={issue.data.total_tokens_spent}
+          onApprovePlan={(note) => {
+            planApprovalResponseMutation.mutate({ approved: true, note });
+          }}
+          onContinue={() => {
+            retryMutation.mutate();
+          }}
+          onRequestPlanRevision={(note) => {
+            planApprovalResponseMutation.mutate({ approved: false, note });
+          }}
+        />
       </div>
 
       {issue.data.issue_type === "recurring" ? (


### PR DESCRIPTION
## Summary
Reworked the issue detail page so the issue metadata, description, assets, comments, issue actions, and agent commands live in one main content flow.

The `Execution triage` section now renders as a full-width sibling below that stack instead of sharing the page with a right-hand control rail.

## Why
The previous layout split the issue page into a main column and a sidebar rail, which separated the issue-management controls from the issue context they act on. This change keeps the operational controls adjacent to the issue content while giving execution triage the visual prominence and width it needs.

## What changed
- Removed the desktop sidebar split from the issue detail page layout.
- Grouped `Issue actions` and `Agent commands` into a dedicated section inside the main content stack.
- Rendered `SessionExecutionCard` below the main stack so execution triage spans the full container width.
- Updated the issue detail layout tests to match the new structure and document order.

## Validation
- `pnpm exec vitest run src/routes/issue-detail.test.tsx src/routes/issue-detail-token-spend.test.tsx`
- `pnpm exec eslint src/routes/issue-detail.tsx src/routes/issue-detail.test.tsx`
- Pre-push hook passed the repo’s frontend lint/test/build/coverage gates and retry-safety e2e checks.

## Notes
No API, schema, or backend behavior changed. This is a frontend layout-only refactor.