### PR TITLE
[codex] Add shadcn/TanStack work issues table

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -57,6 +58,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "4.1.3",
     "eslint": "^10.2.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
@@ -64,7 +66,6 @@
     "jsdom": "^29.0.2",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.2",
-    "@vitest/coverage-v8": "4.1.3",
     "typescript-eslint": "^8.58.1",
     "vite": "^8.0.7",
     "vitest": "4.1.3"

--- a/apps/frontend/src/components/dashboard/work-issue-surface.tsx
+++ b/apps/frontend/src/components/dashboard/work-issue-surface.tsx
@@ -1,17 +1,14 @@
-import { Link } from "@tanstack/react-router";
 import { type ReactNode } from "react";
 import { LayoutGrid, Table2 } from "lucide-react";
 
 import { KanbanBoard } from "@/components/dashboard/kanban-board";
-import { Badge } from "@/components/ui/badge";
+import { WorkIssueTable } from "@/components/dashboard/work-issue-table";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   ToggleGroup,
   ToggleGroupItem,
 } from "@/components/ui/toggle-group";
 import { useIsMobileLayout } from "@/hooks/use-is-mobile-layout";
-import { getSessionForIssue, getStateMeta } from "@/lib/dashboard";
-import { appRoutes } from "@/lib/routes";
 import type { WorkSort, WorkView } from "@/lib/work-url-state";
 import type {
   DashboardWorkSource,
@@ -19,16 +16,6 @@ import type {
   IssueStateCounts,
   IssueSummary,
 } from "@/lib/types";
-import { formatRelativeTime } from "@/lib/utils";
-
-const issueSortColumns = [
-  { value: "identifier_asc", label: "Issue", ariaSort: "ascending" as const },
-  { value: "state_asc", label: "State", ariaSort: "ascending" as const },
-  { value: "priority_asc", label: "Priority", ariaSort: "ascending" as const },
-  { value: "project_asc", label: "Project", ariaSort: "ascending" as const },
-  { value: "epic_asc", label: "Epic", ariaSort: "ascending" as const },
-  { value: "updated_desc", label: "Updated", ariaSort: "descending" as const },
-] as const;
 
 export function WorkIssueSurface({
   title,
@@ -63,14 +50,6 @@ export function WorkIssueSurface({
 }) {
   const isMobileLayout = useIsMobileLayout();
   const showBoardView = isMobileLayout || view === "board";
-  const projectColumnClass = showProjectColumn ? "w-[14%]" : "";
-  const epicColumnClass = showProjectColumn ? "w-[18%] pl-5" : "w-[22%]";
-  const issueColumnClass = showProjectColumn ? "w-[34%]" : "w-[40%]";
-  const stateColumnClass = "w-[12%]";
-  const priorityColumnClass = "w-[10%]";
-  const updatedColumnClass = showProjectColumn ? "w-[12%]" : "w-[14%]";
-  const tableMinWidthClass = showProjectColumn ? "min-w-[1120px]" : "min-w-[960px]";
-  const visibleColumns = issueSortColumns.filter((column) => showProjectColumn || column.value !== "project_asc");
 
   return (
     <div className="grid gap-[var(--section-gap)]">
@@ -134,170 +113,16 @@ export function WorkIssueSurface({
       ) : (
         <div className="m-0">
           <Card>
-            <CardContent className="overflow-x-auto pt-[var(--panel-padding)]">
-              <table className={`w-full table-fixed text-left text-sm ${tableMinWidthClass}`}>
-                <thead className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
-                  <tr>
-                    {visibleColumns.map((column) => {
-                      const isActive = sort === column.value;
-                      const columnClass =
-                        column.value === "identifier_asc"
-                          ? issueColumnClass
-                          : column.value === "state_asc"
-                            ? stateColumnClass
-                            : column.value === "priority_asc"
-                              ? priorityColumnClass
-                              : column.value === "project_asc"
-                                ? projectColumnClass
-                                : column.value === "epic_asc"
-                                  ? epicColumnClass
-                                  : updatedColumnClass;
-
-                      return (
-                        <th
-                          key={column.value}
-                          aria-sort={isActive ? column.ariaSort : undefined}
-                          className={`pb-4 align-bottom ${columnClass}`}
-                          scope="col"
-                        >
-                          <button
-                            aria-label={`Sort by ${column.label}`}
-                            className={`inline-flex items-center gap-1 text-left font-medium transition ${
-                              isActive
-                                ? "text-white"
-                                : "text-[var(--muted-foreground)] hover:text-white"
-                            }`}
-                            onClick={() => onSortChange(column.value)}
-                            type="button"
-                          >
-                            {column.label}
-                          </button>
-                        </th>
-                      );
-                    })}
-                    {renderListActions ? (
-                      <th className="w-[120px] pb-4 align-bottom text-right">
-                        Actions
-                      </th>
-                    ) : null}
-                  </tr>
-                </thead>
-                <tbody>
-                  {items.map((issue) => {
-                    const liveSession = getSessionForIssue(
-                      bootstrap,
-                      issue.id,
-                      issue.identifier,
-                    );
-
-                    return (
-                      <tr key={issue.id} className="border-t border-white/6">
-                        <td className="py-4 align-top">
-                          <button
-                            className="flex min-w-0 flex-col items-start gap-1 text-left"
-                            onClick={() => onOpenIssue(issue)}
-                            type="button"
-                          >
-                            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                              <p className="truncate font-mono text-xs uppercase tracking-[0.22em] text-[var(--muted-foreground)]">
-                                {issue.identifier}
-                              </p>
-                              {liveSession ? (
-                                <Badge className="border-lime-400/20 bg-lime-400/10 px-1.5 py-0.5 text-[9px] tracking-[0.14em] text-lime-200">
-                                  Live
-                                </Badge>
-                              ) : null}
-                              {issue.is_blocked ? (
-                                <Badge className="border-red-500/20 bg-red-500/10 px-1.5 py-0.5 text-[9px] tracking-[0.14em] text-red-100">
-                                  Blocked
-                                </Badge>
-                              ) : null}
-                            </div>
-                            <p
-                              className="truncate text-sm font-medium leading-5 text-white"
-                              title={issue.title}
-                            >
-                              {issue.title}
-                            </p>
-                          </button>
-                        </td>
-                        <td className="py-4 align-top">
-                          <Badge className="border-white/10 bg-white/5 text-white">
-                            {getStateMeta(issue.state).label}
-                          </Badge>
-                        </td>
-                        <td className="py-4 align-top">
-                          {issue.priority > 0 ? (
-                            <Badge
-                              aria-label={`Priority ${issue.priority}`}
-                              className="border-amber-400/20 bg-amber-400/10 text-amber-200"
-                              title={`Priority ${issue.priority}`}
-                            >
-                              P{issue.priority}
-                            </Badge>
-                          ) : (
-                            <Badge
-                              aria-label="No priority"
-                              className="border-white/10 bg-white/5 text-[var(--muted-foreground)]"
-                              title="No priority"
-                            >
-                              —
-                            </Badge>
-                          )}
-                        </td>
-                        {showProjectColumn ? (
-                          <td className="py-4 align-top text-[var(--muted-foreground)]">
-                            {issue.project_id ? (
-                              <Link
-                                className="block truncate text-inherit transition hover:text-white"
-                                params={{ projectId: issue.project_id }}
-                                title={issue.project_name || "Unassigned"}
-                                to={appRoutes.projectDetail}
-                              >
-                                {issue.project_name || "Unassigned"}
-                              </Link>
-                            ) : (
-                              <span className="block truncate" title="Unassigned">
-                                Unassigned
-                              </span>
-                            )}
-                          </td>
-                        ) : null}
-                        <td
-                          className={`py-4 align-top text-[var(--muted-foreground)] ${
-                            showProjectColumn ? "pl-5" : ""
-                          }`}
-                        >
-                          {issue.epic_id ? (
-                            <Link
-                              className="block truncate text-inherit transition hover:text-white"
-                              params={{ epicId: issue.epic_id }}
-                              title={issue.epic_name || "None"}
-                              to={appRoutes.epicDetail}
-                            >
-                              {issue.epic_name || "None"}
-                            </Link>
-                          ) : (
-                            <span className="block truncate" title="None">
-                              None
-                            </span>
-                          )}
-                        </td>
-                        <td className="whitespace-nowrap py-4 align-top text-[var(--muted-foreground)]">
-                          {formatRelativeTime(issue.updated_at)}
-                        </td>
-                        {renderListActions ? (
-                          <td className="py-4 align-top">
-                            <div className="flex justify-end gap-2">
-                              {renderListActions(issue)}
-                            </div>
-                          </td>
-                        ) : null}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+            <CardContent className="pt-[var(--panel-padding)]">
+              <WorkIssueTable
+                bootstrap={bootstrap}
+                items={items}
+                onOpenIssue={onOpenIssue}
+                onSortChange={onSortChange}
+                renderListActions={renderListActions}
+                showProjectColumn={showProjectColumn}
+                sort={sort}
+              />
             </CardContent>
           </Card>
         </div>

--- a/apps/frontend/src/components/dashboard/work-issue-table.test.tsx
+++ b/apps/frontend/src/components/dashboard/work-issue-table.test.tsx
@@ -1,0 +1,112 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { makeIssueSummary } from "@/test/fixtures";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: (props: {
+    children: ReactNode;
+    to?: unknown;
+    params?: Record<string, string>;
+  } & AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    const { children, to, params, ...anchorProps } = props;
+    void to;
+    void params;
+
+    return <a {...anchorProps}>{children}</a>;
+  },
+}));
+
+import { WorkIssueTable } from "@/components/dashboard/work-issue-table";
+
+describe("WorkIssueTable", () => {
+  it("renders sortable headers and truncates long issue metadata", () => {
+    const longTitle =
+      "Implement an exceptionally long issue title that should be truncated in the list table";
+    const longProject =
+      "Platform with a very long project name that should not stretch the table";
+    const longEpic =
+      "Observability with a very long epic name that should not stretch the table";
+    const issue = makeIssueSummary({
+      identifier: "ISS-123",
+      title: longTitle,
+      project_id: "project-1",
+      project_name: longProject,
+      epic_id: "epic-1",
+      epic_name: longEpic,
+      updated_at: "2026-03-09T11:00:00Z",
+    });
+    const onSortChange = vi.fn();
+    const onOpenIssue = vi.fn();
+
+    render(
+      <WorkIssueTable
+        items={[issue]}
+        sort="updated_desc"
+        onOpenIssue={onOpenIssue}
+        onSortChange={onSortChange}
+        renderListActions={() => <button type="button">Move</button>}
+        showProjectColumn
+      />,
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sort by Issue" })).toHaveClass("text-xs");
+    expect(screen.getByRole("columnheader", { name: "Updated" })).toHaveAttribute(
+      "aria-sort",
+      "descending",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort by Issue" }));
+
+    expect(onSortChange).toHaveBeenCalledWith("identifier_asc");
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /ISS-123.*long issue title/i })).toHaveClass(
+      "overflow-hidden",
+    );
+    expect(
+      screen.getByRole("columnheader", { name: "Actions" }).querySelector("div"),
+    ).toHaveClass(
+      "flex",
+      "items-center",
+      "justify-end",
+      "px-2",
+      "text-xs",
+      "font-medium",
+      "leading-4",
+      "normal-case",
+    );
+    expect(screen.getByText(longTitle)).toHaveClass("truncate", "w-full");
+    expect(screen.getByText(longTitle)).toHaveAttribute("title", longTitle);
+    expect(screen.getByText(longProject).closest("a")).toHaveClass("truncate", "w-full");
+    expect(screen.getByText(longProject)).toHaveAttribute("title", longProject);
+    expect(screen.getByText(longEpic).closest("a")).toHaveClass("truncate", "w-full");
+    expect(screen.getByText(longEpic)).toHaveAttribute("title", longEpic);
+  });
+
+  it("hides the project column when requested", () => {
+    const issue = makeIssueSummary({
+      project_id: undefined,
+      project_name: undefined,
+      epic_id: "epic-1",
+      epic_name: "Observability",
+    });
+
+    render(
+      <WorkIssueTable
+        items={[issue]}
+        sort="priority_asc"
+        onOpenIssue={vi.fn()}
+        onSortChange={vi.fn()}
+        showProjectColumn={false}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Issue" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Project" })).not.toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Epic" })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/dashboard/work-issue-table.tsx
+++ b/apps/frontend/src/components/dashboard/work-issue-table.tsx
@@ -1,0 +1,412 @@
+import { Link } from "@tanstack/react-router";
+import {
+  flexRender,
+  getCoreRowModel,
+  type ColumnDef,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getSessionForIssue, getStateMeta } from "@/lib/dashboard";
+import { appRoutes } from "@/lib/routes";
+import type { DashboardWorkSource, IssueSummary } from "@/lib/types";
+import { formatRelativeTime, cn } from "@/lib/utils";
+import type { WorkSort } from "@/lib/work-url-state";
+
+type IssueColumnId =
+  | "identifier"
+  | "state"
+  | "priority"
+  | "project"
+  | "epic"
+  | "updated"
+  | "actions";
+
+const sortableColumns: Record<
+  Exclude<IssueColumnId, "actions">,
+  { sort: WorkSort; ariaSort: "ascending" | "descending"; label: string }
+> = {
+  identifier: { sort: "identifier_asc", ariaSort: "ascending", label: "Issue" },
+  state: { sort: "state_asc", ariaSort: "ascending", label: "State" },
+  priority: { sort: "priority_asc", ariaSort: "ascending", label: "Priority" },
+  project: { sort: "project_asc", ariaSort: "ascending", label: "Project" },
+  epic: { sort: "epic_asc", ariaSort: "ascending", label: "Epic" },
+  updated: { sort: "updated_desc", ariaSort: "descending", label: "Updated" },
+};
+
+function sortingForWorkSort(sort: WorkSort): SortingState {
+  switch (sort) {
+    case "identifier_asc":
+      return [{ id: "identifier", desc: false }];
+    case "state_asc":
+      return [{ id: "state", desc: false }];
+    case "priority_asc":
+      return [{ id: "priority", desc: false }];
+    case "project_asc":
+      return [{ id: "project", desc: false }];
+    case "epic_asc":
+      return [{ id: "epic", desc: false }];
+    case "updated_desc":
+    default:
+      return [{ id: "updated", desc: true }];
+  }
+}
+
+function getColumnWidthClass(columnId: IssueColumnId, showProjectColumn: boolean) {
+  switch (columnId) {
+    case "identifier":
+      return showProjectColumn ? "w-[30%]" : "w-[36%]";
+    case "state":
+      return "w-[11%]";
+    case "priority":
+      return "w-[9%]";
+    case "project":
+      return "w-[13%]";
+    case "epic":
+      return showProjectColumn ? "w-[17%] pl-4" : "w-[21%]";
+    case "updated":
+      return showProjectColumn ? "w-[10%]" : "w-[12%]";
+    case "actions":
+      return "w-[120px]";
+  }
+}
+
+function getAriaSort(
+  columnId: Exclude<IssueColumnId, "actions">,
+  sort: WorkSort,
+): "ascending" | "descending" | undefined {
+  return sortableColumns[columnId].sort === sort
+    ? sortableColumns[columnId].ariaSort
+    : undefined;
+}
+
+function IssueIdentityCell({
+  bootstrap,
+  issue,
+  onOpenIssue,
+}: {
+  bootstrap?: DashboardWorkSource;
+  issue: IssueSummary;
+  onOpenIssue: (issue: IssueSummary) => void;
+}) {
+  const liveSession = getSessionForIssue(bootstrap, issue.id, issue.identifier);
+
+  return (
+    <button
+      className="flex w-full min-w-0 flex-col items-start gap-1 overflow-hidden text-left"
+      onClick={() => onOpenIssue(issue)}
+      type="button"
+    >
+      <div className="flex min-w-0 max-w-full flex-wrap items-center gap-1.5">
+        <p className="truncate font-mono text-xs uppercase tracking-[0.22em] text-[var(--muted-foreground)]">
+          {issue.identifier}
+        </p>
+        {liveSession ? (
+          <Badge className="border-lime-400/20 bg-lime-400/10 px-1.5 py-0.5 text-[9px] tracking-[0.14em] text-lime-200">
+            Live
+          </Badge>
+        ) : null}
+        {issue.is_blocked ? (
+          <Badge className="border-red-500/20 bg-red-500/10 px-1.5 py-0.5 text-[9px] tracking-[0.14em] text-red-100">
+            Blocked
+          </Badge>
+        ) : null}
+      </div>
+      <p className="block w-full truncate text-sm font-medium leading-5 text-white" title={issue.title}>
+        {issue.title}
+      </p>
+    </button>
+  );
+}
+
+function issueColumns({
+  bootstrap,
+  onOpenIssue,
+  onSortChange,
+  renderListActions,
+  showProjectColumn,
+}: {
+  bootstrap?: DashboardWorkSource;
+  onOpenIssue: (issue: IssueSummary) => void;
+  onSortChange: (sort: WorkSort) => void;
+  renderListActions?: (issue: IssueSummary) => ReactNode;
+  showProjectColumn: boolean;
+}): ColumnDef<IssueSummary>[] {
+  const columns: ColumnDef<IssueSummary>[] = [
+    {
+      id: "identifier",
+      accessorKey: "identifier",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          column={column}
+          title={sortableColumns.identifier.label}
+          onSortChange={onSortChange}
+          sortValue={sortableColumns.identifier.sort}
+        />
+      ),
+      cell: ({ row }) => (
+        <IssueIdentityCell bootstrap={bootstrap} issue={row.original} onOpenIssue={onOpenIssue} />
+      ),
+    },
+    {
+      id: "state",
+      accessorKey: "state",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          column={column}
+          title={sortableColumns.state.label}
+          onSortChange={onSortChange}
+          sortValue={sortableColumns.state.sort}
+        />
+      ),
+      cell: ({ row }) => (
+        <Badge className="border-white/10 bg-white/5 text-white">
+          {getStateMeta(row.original.state).label}
+        </Badge>
+      ),
+    },
+    {
+      id: "priority",
+      accessorKey: "priority",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          column={column}
+          title={sortableColumns.priority.label}
+          onSortChange={onSortChange}
+          sortValue={sortableColumns.priority.sort}
+        />
+      ),
+      cell: ({ row }) =>
+        row.original.priority > 0 ? (
+          <Badge
+            aria-label={`Priority ${row.original.priority}`}
+            className="border-amber-400/20 bg-amber-400/10 text-amber-200"
+            title={`Priority ${row.original.priority}`}
+          >
+            P{row.original.priority}
+          </Badge>
+        ) : (
+          <Badge
+            aria-label="No priority"
+            className="border-white/10 bg-white/5 text-[var(--muted-foreground)]"
+            title="No priority"
+          >
+            —
+          </Badge>
+        ),
+    },
+  ];
+
+  if (showProjectColumn) {
+    columns.push(
+      {
+        id: "project",
+        accessorKey: "project_name",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={sortableColumns.project.label}
+            onSortChange={onSortChange}
+            sortValue={sortableColumns.project.sort}
+          />
+        ),
+        cell: ({ row }) =>
+          row.original.project_id ? (
+            <Link
+              className="block w-full min-w-0 truncate text-inherit transition hover:text-white"
+              params={{ projectId: row.original.project_id }}
+              title={row.original.project_name || "Unassigned"}
+              to={appRoutes.projectDetail}
+            >
+              {row.original.project_name || "Unassigned"}
+            </Link>
+          ) : (
+            <span className="block w-full min-w-0 truncate" title="Unassigned">
+              Unassigned
+            </span>
+          ),
+      },
+    );
+  }
+
+  columns.push(
+    {
+      id: "epic",
+      accessorKey: "epic_name",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          column={column}
+          title={sortableColumns.epic.label}
+          onSortChange={onSortChange}
+          sortValue={sortableColumns.epic.sort}
+        />
+      ),
+      cell: ({ row }) =>
+        row.original.epic_id ? (
+          <Link
+            className="block w-full min-w-0 truncate text-inherit transition hover:text-white"
+            params={{ epicId: row.original.epic_id }}
+            title={row.original.epic_name || "None"}
+            to={appRoutes.epicDetail}
+          >
+            {row.original.epic_name || "None"}
+          </Link>
+        ) : (
+          <span className="block w-full min-w-0 truncate" title="None">
+            None
+          </span>
+        ),
+    },
+    {
+      id: "updated",
+      accessorKey: "updated_at",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          column={column}
+          title={sortableColumns.updated.label}
+          onSortChange={onSortChange}
+          sortValue={sortableColumns.updated.sort}
+        />
+      ),
+      cell: ({ row }) => (
+        <span className="block w-full min-w-0 truncate whitespace-nowrap text-[var(--muted-foreground)]">
+          {formatRelativeTime(row.original.updated_at)}
+        </span>
+      ),
+    },
+  );
+
+  if (renderListActions) {
+    columns.push(
+      {
+        id: "actions",
+        header: () => (
+          <div className="flex h-8 items-center justify-end px-2 text-xs font-medium leading-4 normal-case">
+            Actions
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="flex justify-end gap-2">{renderListActions(row.original)}</div>
+        ),
+      },
+    );
+  }
+
+  return columns;
+}
+
+export function WorkIssueTable({
+  bootstrap,
+  items,
+  onOpenIssue,
+  onSortChange,
+  renderListActions,
+  showProjectColumn = true,
+  sort,
+}: {
+  bootstrap?: DashboardWorkSource;
+  items: IssueSummary[];
+  onOpenIssue: (issue: IssueSummary) => void;
+  onSortChange: (sort: WorkSort) => void;
+  renderListActions?: (issue: IssueSummary) => ReactNode;
+  showProjectColumn?: boolean;
+  sort: WorkSort;
+}) {
+  // TanStack Table intentionally returns helper functions that the React compiler flags here.
+  // The table is still controlled by props, so this warning is expected.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: items,
+    columns: issueColumns({
+      bootstrap,
+      onOpenIssue,
+      onSortChange,
+      renderListActions,
+      showProjectColumn,
+    }),
+    state: {
+      sorting: sortingForWorkSort(sort),
+    },
+    manualSorting: true,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+  });
+
+  const tableMinWidthClass = showProjectColumn ? "min-w-[1120px]" : "min-w-[960px]";
+
+  return (
+    <div className="overflow-x-auto">
+      <Table className={cn("table-fixed text-left text-sm", tableMinWidthClass)}>
+        <TableHeader className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                const columnId = header.column.id as IssueColumnId;
+                const ariaSort =
+                  columnId === "actions"
+                    ? undefined
+                    : getAriaSort(columnId, sort);
+
+                return (
+                  <TableHead
+                    key={header.id}
+                    aria-sort={ariaSort}
+                    className={cn(
+                      "px-0 pb-4 align-bottom",
+                      getColumnWidthClass(columnId, showProjectColumn),
+                      columnId === "actions" ? "text-right" : "",
+                    )}
+                    scope="col"
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell
+                  key={cell.id}
+                  className={cn(
+                    "px-0 py-4 align-top overflow-hidden",
+                    getColumnWidthClass(cell.column.id as IssueColumnId, showProjectColumn),
+                    cell.column.id === "state" ||
+                      cell.column.id === "priority" ||
+                      cell.column.id === "updated" ||
+                      cell.column.id === "actions"
+                      ? ""
+                      : "min-w-0",
+                    cell.column.id === "updated" ? "whitespace-nowrap" : "",
+                    cell.column.id === "actions" ? "text-right" : "",
+                  )}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/data-table-column-header.tsx
+++ b/apps/frontend/src/components/ui/data-table-column-header.tsx
@@ -1,0 +1,49 @@
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
+import type { Column } from "@tanstack/react-table";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { WorkSort } from "@/lib/work-url-state";
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  onSortChange,
+  sortValue,
+  className,
+}: {
+  column: Column<TData, TValue>;
+  title: string;
+  onSortChange: (sort: WorkSort) => void;
+  sortValue: WorkSort;
+  className?: string;
+}) {
+  if (!column.getCanSort()) {
+    return <div className={cn(className)}>{title}</div>;
+  }
+
+  const isSorted = column.getIsSorted();
+
+  return (
+    <Button
+      aria-label={`Sort by ${title}`}
+      className={cn(
+        "h-8 justify-start gap-1.5 px-2 font-medium text-xs",
+        className,
+      )}
+      size="sm"
+      type="button"
+      variant="ghost"
+      onClick={() => onSortChange(sortValue)}
+    >
+      <span className="truncate">{title}</span>
+      {isSorted === "desc" ? (
+        <ArrowDown className="size-4 shrink-0" />
+      ) : isSorted === "asc" ? (
+        <ArrowUp className="size-4 shrink-0" />
+      ) : (
+        <ChevronsUpDown className="size-4 shrink-0 text-[var(--muted-foreground)]" />
+      )}
+    </Button>
+  );
+}

--- a/apps/frontend/src/components/ui/table.tsx
+++ b/apps/frontend/src/components/ui/table.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.TableHTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b border-white/8 transition-colors hover:bg-white/[0.03] data-[state=selected]:bg-white/[0.06]",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-[var(--muted-foreground)] [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "px-4 py-4 align-middle [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-[var(--muted-foreground)]", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.168.10
         version: 1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2118,6 +2121,13 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   '@tanstack/router-core@1.168.9':
     resolution: {integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==}
     engines: {node: '>=20.19'}
@@ -2125,6 +2135,10 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -6408,6 +6422,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.168.9':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -6416,6 +6436,8 @@ snapshots:
       seroval-plugins: 1.5.2(seroval@1.5.2)
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Replaced the shared work issues list view with a local TanStack Table implementation built on the shadcn/ui table primitives.
- Kept sort state URL-driven and server-authoritative while preserving the existing work view toggle and issue actions.
- Added CSS truncation and fixed header alignment so long issue, project, and epic text stays contained and the Actions header matches the rest of the table.

## Details
- Introduced a reusable `DataTableColumnHeader` helper for sortable columns.
- Extracted the work-issues list into a focused table component used by the shared work surface.
- Added regression coverage for sortable headers, truncation, project-column hiding, and the Actions header styling.

## Validation
- `pnpm --filter @maestro/frontend exec vitest run src/components/dashboard/work-issue-table.test.tsx src/routes/work.test.tsx src/routes/project-detail.test.tsx`
- `pnpm --filter @maestro/frontend build`
- Repository pre-commit and pre-push hooks completed successfully during `git commit` and `git push`.