### PR TITLE
fix(monorepo): bootstrap dashboard dist before e2e builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "verify:website": "pnpm website:check && pnpm website:test",
     "verify:web": "pnpm lint && pnpm test && pnpm check && pnpm smoke",
     "verify:go": "make build && make test && make test-cover && make test-race",
-    "verify:package": "node --test packaging/npm/root/lib/get-exe-path.test.js scripts/smoke_installed_dashboard.test.mjs scripts/verify-pipeline.test.mjs && bash ./scripts/publish_npm_release.test.sh",
+    "verify:package": "node --test packaging/npm/root/lib/get-exe-path.test.js scripts/smoke_installed_dashboard.test.mjs scripts/verify-pipeline.test.mjs && bash ./scripts/e2e_harness_bootstrap.test.sh && bash ./scripts/publish_npm_release.test.sh",
     "release:npm": "./scripts/publish_npm_release.sh",
     "hooks:pre-commit": "./scripts/git-hooks/pre-commit.sh",
     "hooks:pre-push": "./scripts/git-hooks/pre-push.sh",

--- a/scripts/e2e_harness_bootstrap.test.sh
+++ b/scripts/e2e_harness_bootstrap.test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  printf 'test: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq -- "$pattern" "$file"; then
+    fail "expected to find '$pattern' in $file"
+  fi
+}
+
+assert_in_order() {
+  local file="$1"
+  shift
+  local previous_line=0
+  local pattern
+  for pattern in "$@"; do
+    local line
+    line="$(grep -nF -- "$pattern" "$file" | head -n 1 | cut -d: -f1 || true)"
+    if [[ -z "$line" ]]; then
+      fail "missing ordered pattern '$pattern' in $file"
+    fi
+    if (( line <= previous_line )); then
+      fail "pattern '$pattern' appeared out of order in $file"
+    fi
+    previous_line="$line"
+  done
+}
+
+make_mock_toolchain() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'codex %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'git %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go %s\n' "$*" >>"$LOG_FILE"
+case "$1" in
+  build)
+    if [[ -f "$MOCK_ROOT_DIR/internal/dashboardui/dist/.e2e-bootstrap-sentinel" ]]; then
+      printf 'dashboard bootstrap sentinel present before go build\n' >>"$LOG_FILE"
+      exit 17
+    fi
+    printf 'dashboard bootstrap sentinel missing before go build\n' >>"$LOG_FILE"
+    exit 99
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+
+  cat >"$bin_dir/python3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'python3 %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/sqlite3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'sqlite3 %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/ensure-dashboard-dist" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ensure-dashboard\n' >>"$LOG_FILE"
+mkdir -p "$MOCK_ROOT_DIR/internal/dashboardui/dist"
+: >"$MOCK_ROOT_DIR/internal/dashboardui/dist/.e2e-bootstrap-sentinel"
+EOF
+
+  chmod +x \
+    "$bin_dir/codex" \
+    "$bin_dir/git" \
+    "$bin_dir/go" \
+    "$bin_dir/python3" \
+    "$bin_dir/sqlite3" \
+    "$bin_dir/ensure-dashboard-dist"
+}
+
+cleanup_sentinel() {
+  rm -f "$ROOT_DIR/internal/dashboardui/dist/.e2e-bootstrap-sentinel"
+}
+
+test_scripts_bootstrap_dashboard_dist_before_build() {
+  local scripts=(
+    "$ROOT_DIR/scripts/e2e_retry_safety.sh"
+    "$ROOT_DIR/scripts/e2e_real_codex.sh"
+    "$ROOT_DIR/scripts/e2e_real_codex_phases.sh"
+    "$ROOT_DIR/scripts/e2e_real_codex_issue_images.sh"
+  )
+
+  local script
+  for script in "${scripts[@]}"; do
+    local tmp_dir bin_dir log_file stdout_file stderr_file
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/e2e-harness-bootstrap.XXXXXX")"
+    bin_dir="$tmp_dir/bin"
+    log_file="$tmp_dir/log.txt"
+    stdout_file="$tmp_dir/stdout.txt"
+    stderr_file="$tmp_dir/stderr.txt"
+
+    make_mock_toolchain "$bin_dir"
+    : >"$log_file"
+    cleanup_sentinel
+
+    if PATH="$bin_dir:$PATH" \
+      LOG_FILE="$log_file" \
+      MOCK_ROOT_DIR="$ROOT_DIR" \
+      MAESTRO_ENSURE_DASHBOARD_DIST_BIN="$bin_dir/ensure-dashboard-dist" \
+      E2E_ROOT="$tmp_dir/harness" \
+      bash "$script" >"$stdout_file" 2>"$stderr_file"; then
+      cleanup_sentinel
+      fail "expected $(basename "$script") to stop after the mocked go build"
+    fi
+
+    assert_in_order "$log_file" "ensure-dashboard" "dashboard bootstrap sentinel present before go build"
+    assert_contains "$log_file" "go build -o "
+    cleanup_sentinel
+  done
+}
+
+main() {
+  test_scripts_bootstrap_dashboard_dist_before_build
+}
+
+main "$@"

--- a/scripts/e2e_real_codex.sh
+++ b/scripts/e2e_real_codex.sh
@@ -18,6 +18,7 @@ KEEP_HARNESS="${E2E_KEEP_HARNESS:-1}"
 ORCH_PID=""
 
 cd "$ROOT_DIR"
+ENSURE_DASHBOARD_DIST_BIN="${MAESTRO_ENSURE_DASHBOARD_DIST_BIN:-$ROOT_DIR/scripts/ensure_dashboard_dist.sh}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -97,6 +98,7 @@ require_cmd sqlite3
 mkdir -p "$BIN_DIR" "$ARTIFACTS_DIR" "$WORKSPACES_DIR" "$LOGS_DIR" "$(dirname "$DB_PATH")"
 
 echo "Building Maestro binary into $MAESTRO_BIN"
+"$ENSURE_DASHBOARD_DIST_BIN"
 go build -o "$MAESTRO_BIN" ./cmd/maestro
 
 CODEX_COMMAND="${E2E_CODEX_COMMAND:-codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd . --add-dir $(printf '%q' "$HARNESS_ROOT") -}"

--- a/scripts/e2e_real_codex_issue_images.sh
+++ b/scripts/e2e_real_codex_issue_images.sh
@@ -27,6 +27,7 @@ KEEP_HARNESS="${E2E_KEEP_HARNESS:-1}"
 ORCH_PID=""
 
 cd "$ROOT_DIR"
+ENSURE_DASHBOARD_DIST_BIN="${MAESTRO_ENSURE_DASHBOARD_DIST_BIN:-$ROOT_DIR/scripts/ensure_dashboard_dist.sh}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -211,6 +212,7 @@ fi
 mkdir -p "$BIN_DIR" "$WORKSPACES_DIR" "$LOGS_DIR" "$(dirname "$DB_PATH")"
 
 echo "Building Maestro binary into $MAESTRO_BIN"
+"$ENSURE_DASHBOARD_DIST_BIN"
 go build -o "$MAESTRO_BIN" ./cmd/maestro
 
 PROJECT_ID="$("$MAESTRO_BIN" project create "Image E2E Project" --repo "$HARNESS_ROOT" --db "$DB_PATH" --quiet)"

--- a/scripts/e2e_real_codex_phases.sh
+++ b/scripts/e2e_real_codex_phases.sh
@@ -18,6 +18,7 @@ KEEP_HARNESS="${E2E_KEEP_HARNESS:-1}"
 ORCH_PID=""
 
 cd "$ROOT_DIR"
+ENSURE_DASHBOARD_DIST_BIN="${MAESTRO_ENSURE_DASHBOARD_DIST_BIN:-$ROOT_DIR/scripts/ensure_dashboard_dist.sh}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -172,6 +173,7 @@ require_cmd sqlite3
 mkdir -p "$BIN_DIR" "$ARTIFACTS_DIR" "$WORKSPACES_DIR" "$LOGS_DIR" "$(dirname "$DB_PATH")"
 
 echo "Building Maestro binary into $MAESTRO_BIN"
+"$ENSURE_DASHBOARD_DIST_BIN"
 go build -o "$MAESTRO_BIN" ./cmd/maestro
 
 CODEX_COMMAND="${E2E_CODEX_COMMAND:-codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd . --add-dir $(printf '%q' "$HARNESS_ROOT") -}"

--- a/scripts/e2e_retry_safety.sh
+++ b/scripts/e2e_retry_safety.sh
@@ -21,6 +21,7 @@ ORCH_PID=""
 
 cd "$ROOT_DIR"
 export MAESTRO_DAEMON_REGISTRY_DIR="$DAEMON_REGISTRY_DIR"
+ENSURE_DASHBOARD_DIST_BIN="${MAESTRO_ENSURE_DASHBOARD_DIST_BIN:-$ROOT_DIR/scripts/ensure_dashboard_dist.sh}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -223,6 +224,7 @@ require_cmd git
 mkdir -p "$BIN_DIR" "$WORKSPACES_DIR" "$LOGS_DIR" "$REPOS_DIR" "$(dirname "$DB_PATH")"
 
 echo "Building Maestro binary into $MAESTRO_BIN"
+"$ENSURE_DASHBOARD_DIST_BIN"
 go build -o "$MAESTRO_BIN" ./cmd/maestro
 echo "Building fake app-server into $FAKE_APPSERVER_BIN"
 go build -o "$FAKE_APPSERVER_BIN" ./cmd/maestro-fake-appserver

--- a/scripts/verify-pipeline.test.mjs
+++ b/scripts/verify-pipeline.test.mjs
@@ -35,6 +35,15 @@ test('verify:ci excludes the Go suite', () => {
   assert.ok(!ci.includes('go test ./...'), 'verify:ci should not run go test ./...')
 })
 
+test('verify:package keeps the real codex harness bootstrap regression test', () => {
+  const pkg = SCRIPTS['verify:package']
+  assert.ok(pkg, 'missing script: verify:package')
+  assert.ok(
+    pkg.includes('scripts/e2e_harness_bootstrap.test.sh'),
+    'verify:package should keep the real codex harness bootstrap regression test',
+  )
+})
+
 test('verify:pre-push keeps the full pre-push gate', () => {
   const prePush = SCRIPTS['verify:pre-push']
   assert.ok(prePush, 'missing script: verify:pre-push')


### PR DESCRIPTION
## What

The nightly GitHub Actions workflow `Real Codex E2E` was failing on fresh checkouts because the harness scripts built `./cmd/maestro` before the embedded dashboard bundle existed.

## Why

`internal/dashboardui/embed.go` embeds `internal/dashboardui/dist/*`, but that directory is generated and not tracked in Git. On CI, the nightly harness started from a clean checkout and hit:

`pattern dist/*: no matching files found`

## What changed

- Bootstrapped the dashboard dist before every real Codex e2e harness build:
  - `scripts/e2e_retry_safety.sh`
  - `scripts/e2e_real_codex.sh`
  - `scripts/e2e_real_codex_phases.sh`
  - `scripts/e2e_real_codex_issue_images.sh`
- Added a regression test that proves the harness calls the dashboard bootstrap helper before `go build`.
- Wired that regression test into `verify:package` and the script-order assertions.

## Verification

- `pnpm verify:ci`
- `git diff --check`
- `bash scripts/e2e_harness_bootstrap.test.sh`
- Local commit and push hooks completed successfully

## Expected result

The nightly `Real Codex E2E` workflow should now be able to build the Maestro binary from a clean checkout, while the bootstrap regression test keeps the fix in the local verification gate.