### PR TITLE
[codex] fix real codex e2e harness bootstrap and coverage hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "verify:website": "pnpm website:check && pnpm website:test",
     "verify:web": "pnpm lint && pnpm test && pnpm check && pnpm smoke",
     "verify:go": "make build && make test && make test-cover && make test-race",
-    "verify:package": "node --test packaging/npm/root/lib/get-exe-path.test.js scripts/smoke_installed_dashboard.test.mjs scripts/verify-pipeline.test.mjs && bash ./scripts/e2e_harness_bootstrap.test.sh && bash ./scripts/publish_npm_release.test.sh",
+    "verify:package": "node --test packaging/npm/root/lib/get-exe-path.test.js scripts/smoke_installed_dashboard.test.mjs scripts/verify-pipeline.test.mjs && bash ./scripts/check_coverage.test.sh && bash ./scripts/e2e_harness_bootstrap.test.sh && bash ./scripts/publish_npm_release.test.sh",
     "release:npm": "./scripts/publish_npm_release.sh",
     "hooks:pre-commit": "./scripts/git-hooks/pre-commit.sh",
     "hooks:pre-push": "./scripts/git-hooks/pre-push.sh",

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -1,39 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${MAESTRO_ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
 "$ROOT_DIR/scripts/ensure_dashboard_dist.sh"
 
-declare -A package_dirs=()
-while IFS= read -r file; do
-  dir="$(dirname "$file")"
-  rel="${dir#"$ROOT_DIR"/}"
-  case "$rel" in
-    cmd/maestro-fake-appserver|\
-    internal/testutil/*|\
-    internal/agentruntime/contracttest|\
-    internal/agentruntime/fake|\
-    internal/agentruntime/testadapter|\
-    internal/appserver/protocol/gen)
-      continue
-      ;;
-  esac
-  package_dirs["$rel"]=1
-done < <(
-  find "$ROOT_DIR/cmd" "$ROOT_DIR/internal" "$ROOT_DIR/pkg" "$ROOT_DIR/skills" \
-    -type f -name '*.go' ! -name '*_test.go' | sort -u
-)
-
-packages=()
-for rel in "${!package_dirs[@]}"; do
-  packages+=("$rel")
-done
-IFS=$'\n' packages=($(printf '%s\n' "${packages[@]}" | sort))
-unset IFS
-
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
+
+package_list="$tmpdir/packages.txt"
+find "$ROOT_DIR/cmd" "$ROOT_DIR/internal" "$ROOT_DIR/pkg" "$ROOT_DIR/skills" \
+  -type f -name '*.go' ! -name '*_test.go' | sort -u | while IFS= read -r file; do
+    dir="$(dirname "$file")"
+    rel="${dir#"$ROOT_DIR"/}"
+    case "$rel" in
+      cmd/maestro-fake-appserver|internal/testutil/*|internal/agentruntime/contracttest|internal/agentruntime/fake|internal/agentruntime/testadapter|internal/appserver/protocol/gen)
+        continue
+        ;;
+    esac
+    printf '%s\n' "$rel"
+  done | sort -u >"$package_list"
+
+packages=()
+while IFS= read -r rel; do
+  [[ -n "$rel" ]] || continue
+  packages+=("$rel")
+done <"$package_list"
+unset IFS
 
 # Set COVERAGE_VERBOSE=1 to print the full per-package table.
 verbose="${COVERAGE_VERBOSE:-0}"

--- a/scripts/check_coverage.test.sh
+++ b/scripts/check_coverage.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="$ROOT_DIR/scripts/check_coverage.sh"
+
+fail() {
+  printf 'test: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq -- "$pattern" "$file"; then
+    fail "expected to find '$pattern' in $file"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Fq -- "$pattern" "$file"; then
+    fail "did not expect to find '$pattern' in $file"
+  fi
+}
+
+assert_count() {
+  local file="$1"
+  local pattern="$2"
+  local expected="$3"
+  local actual
+  actual="$(grep -Fc -- "$pattern" "$file" || true)"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "expected '$pattern' to appear $expected times in $file, got $actual"
+  fi
+}
+
+make_mock_toolchain() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go %s\n' "$*" >>"$LOG_FILE"
+if [[ "${1:-}" == "test" ]]; then
+  profile=""
+  pkg=""
+  while (($#)); do
+    case "$1" in
+      -coverprofile=*)
+        profile="${1#-coverprofile=}"
+        shift
+        ;;
+      ./*)
+        pkg="$1"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [[ -z "$profile" || -z "$pkg" ]]; then
+    exit 41
+  fi
+  printf 'mode: set\n%s/file.go:1.1,1.2 1 1\n' "$pkg" >"$profile"
+  exit 0
+fi
+if [[ "${1:-}" == "tool" && "${2:-}" == "cover" ]]; then
+  printf 'total: (statements) 95.0%%\n'
+  exit 0
+fi
+exit 42
+EOF
+
+  chmod +x "$bin_dir/go"
+}
+
+test_runs_under_system_bash_without_associative_arrays() {
+  local tmp_dir repo_dir bin_dir log_file
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/check-coverage.XXXXXX")"
+  repo_dir="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  log_file="$tmp_dir/log.txt"
+
+  mkdir -p \
+    "$repo_dir/scripts" \
+    "$repo_dir/cmd/app" \
+    "$repo_dir/internal/keep" \
+    "$repo_dir/internal/testutil/skip" \
+    "$repo_dir/internal/agentruntime/fake" \
+    "$repo_dir/pkg/lib" \
+    "$repo_dir/skills"
+  printf 'package main\n' >"$repo_dir/cmd/app/main.go"
+  printf 'package main\n' >"$repo_dir/cmd/app/extra.go"
+  printf 'package keep\n' >"$repo_dir/internal/keep/worker.go"
+  printf 'package skip\n' >"$repo_dir/internal/testutil/skip/ignored.go"
+  printf 'package fake\n' >"$repo_dir/internal/agentruntime/fake/ignored.go"
+  printf 'package lib\n' >"$repo_dir/pkg/lib/lib.go"
+  cat >"$repo_dir/scripts/ensure_dashboard_dist.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ensure-dashboard\n' >>"$LOG_FILE"
+EOF
+  chmod +x "$repo_dir/scripts/ensure_dashboard_dist.sh"
+
+  : >"$log_file"
+  make_mock_toolchain "$bin_dir"
+
+  PATH="$bin_dir:/usr/bin:/bin" \
+  LOG_FILE="$log_file" \
+  MAESTRO_ROOT_DIR="$repo_dir" \
+  /bin/bash "$SCRIPT_UNDER_TEST" >"$tmp_dir/stdout.txt" 2>"$tmp_dir/stderr.txt"
+
+  assert_contains "$log_file" "ensure-dashboard"
+  assert_contains "$tmp_dir/stdout.txt" "Checking coverage for 3 packages at 90% threshold"
+  assert_count "$log_file" "go test -coverprofile=" "3"
+  assert_contains "$log_file" "go test -coverprofile="
+  assert_contains "$log_file" "./cmd/app"
+  assert_contains "$log_file" "./internal/keep"
+  assert_contains "$log_file" "./pkg/lib"
+  assert_not_contains "$log_file" "./internal/testutil/skip"
+  assert_not_contains "$log_file" "./internal/agentruntime/fake"
+  assert_count "$log_file" "./cmd/app" "1"
+}
+
+main() {
+  test_runs_under_system_bash_without_associative_arrays
+}
+
+main "$@"

--- a/scripts/e2e_harness_bootstrap.test.sh
+++ b/scripts/e2e_harness_bootstrap.test.sh
@@ -103,6 +103,98 @@ EOF
     "$bin_dir/ensure-dashboard-dist"
 }
 
+make_project_create_mock_toolchain() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'codex %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go %s\n' "$*" >>"$LOG_FILE"
+if [[ "${1:-}" != "build" ]]; then
+  exit 0
+fi
+
+output=""
+while (($#)); do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$output" ]]; then
+  printf 'missing go build output path\n' >>"$LOG_FILE"
+  exit 91
+fi
+
+cat >"$output" <<'INNER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'maestro %s\n' "$*" >>"$LOG_FILE"
+if [[ "${1:-}" == "project" && "${2:-}" == "create" ]]; then
+  repo_path=""
+  shift 2
+  while (($#)); do
+    case "$1" in
+      --repo)
+        repo_path="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [[ -z "$repo_path" ]]; then
+    printf 'missing repo path for project create\n' >&2
+    exit 41
+  fi
+  git -C "$repo_path" rev-parse --show-toplevel >/dev/null 2>&1 || exit 42
+  git -C "$repo_path" rev-parse HEAD >/dev/null 2>&1 || exit 43
+  if [[ "$(git -C "$repo_path" branch --show-current)" != "main" ]]; then
+    exit 44
+  fi
+  printf 'proj_test\n'
+  exit 0
+fi
+exit 45
+INNER
+chmod +x "$output"
+EOF
+
+  cat >"$bin_dir/sqlite3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'sqlite3 %s\n' "$*" >>"$LOG_FILE"
+exit 67
+EOF
+
+  cat >"$bin_dir/ensure-dashboard-dist" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ensure-dashboard\n' >>"$LOG_FILE"
+EOF
+
+  chmod +x \
+    "$bin_dir/codex" \
+    "$bin_dir/go" \
+    "$bin_dir/sqlite3" \
+    "$bin_dir/ensure-dashboard-dist"
+}
+
 cleanup_sentinel() {
   rm -f "$ROOT_DIR/internal/dashboardui/dist/.e2e-bootstrap-sentinel"
 }
@@ -144,8 +236,59 @@ test_scripts_bootstrap_dashboard_dist_before_build() {
   done
 }
 
+test_scripts_initialize_git_repo_before_project_create() {
+  local scripts=(
+    "$ROOT_DIR/scripts/e2e_real_codex.sh"
+    "$ROOT_DIR/scripts/e2e_real_codex_phases.sh"
+    "$ROOT_DIR/scripts/e2e_real_codex_issue_images.sh"
+  )
+
+  local script
+  for script in "${scripts[@]}"; do
+    local tmp_dir bin_dir log_file stdout_file stderr_file harness_root repo_top normalized_harness_root current_branch
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/e2e-harness-git-bootstrap.XXXXXX")"
+    bin_dir="$tmp_dir/bin"
+    log_file="$tmp_dir/log.txt"
+    stdout_file="$tmp_dir/stdout.txt"
+    stderr_file="$tmp_dir/stderr.txt"
+    harness_root="$tmp_dir/harness"
+
+    make_project_create_mock_toolchain "$bin_dir"
+    : >"$log_file"
+
+    if PATH="$bin_dir:$PATH" \
+      LOG_FILE="$log_file" \
+      MAESTRO_ENSURE_DASHBOARD_DIST_BIN="$bin_dir/ensure-dashboard-dist" \
+      E2E_ROOT="$harness_root" \
+      bash "$script" >"$stdout_file" 2>"$stderr_file"; then
+      fail "expected $(basename "$script") to stop after the mocked project create path"
+    fi
+
+    assert_contains "$log_file" "maestro project create"
+    repo_top="$(git -C "$harness_root" rev-parse --show-toplevel 2>/dev/null || true)"
+    normalized_harness_root="$(cd "$harness_root" && pwd -P)"
+    if [[ -n "$repo_top" ]]; then
+      repo_top="$(cd "$repo_top" && pwd -P)"
+    fi
+    if [[ "$repo_top" != "$normalized_harness_root" ]]; then
+      fail "expected $harness_root to be a git repo before project create for $(basename "$script")"
+    fi
+    if ! git -C "$harness_root" rev-parse HEAD >/dev/null 2>&1; then
+      fail "expected $harness_root to have an initial commit for $(basename "$script")"
+    fi
+    current_branch="$(git -C "$harness_root" branch --show-current)"
+    if [[ "$current_branch" != "main" ]]; then
+      fail "expected $harness_root to be on main before project create for $(basename "$script"), got '$current_branch'"
+    fi
+    if ! git -C "$harness_root" ls-files --error-unmatch WORKFLOW.md >/dev/null 2>&1; then
+      fail "expected WORKFLOW.md to be tracked in $harness_root for $(basename "$script")"
+    fi
+  done
+}
+
 main() {
   test_scripts_bootstrap_dashboard_dist_before_build
+  test_scripts_initialize_git_repo_before_project_create
 }
 
 main "$@"

--- a/scripts/e2e_real_codex.sh
+++ b/scripts/e2e_real_codex.sh
@@ -27,6 +27,20 @@ require_cmd() {
   fi
 }
 
+init_git_repo() {
+  local repo_path="$1"
+  (
+    cd "$repo_path"
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_PREFIX
+    git init -q
+    git config user.name "Maestro E2E"
+    git config user.email "e2e@example.com"
+    git add WORKFLOW.md
+    git commit -q -m "test init"
+    git branch -M main
+  )
+}
+
 cleanup() {
   local exit_code="$?"
   if [[ -n "$ORCH_PID" ]] && kill -0 "$ORCH_PID" >/dev/null 2>&1; then
@@ -164,6 +178,8 @@ Requirements:
 6. Do not open a pull request.
 7. Stop after the issue is marked done.
 EOF
+
+init_git_repo "$HARNESS_ROOT"
 
 PROJECT_ID="$("$MAESTRO_BIN" project create "Real Codex E2E Project" --repo "$HARNESS_ROOT" --db "$DB_PATH" --quiet)"
 start_project "$PROJECT_ID"

--- a/scripts/e2e_real_codex_issue_images.sh
+++ b/scripts/e2e_real_codex_issue_images.sh
@@ -36,6 +36,20 @@ require_cmd() {
   fi
 }
 
+init_git_repo() {
+  local repo_path="$1"
+  (
+    cd "$repo_path"
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_PREFIX
+    git init -q
+    git config user.name "Maestro E2E"
+    git config user.email "e2e@example.com"
+    git add WORKFLOW.md
+    git commit -q -m "test init"
+    git branch -M main
+  )
+}
+
 cleanup() {
   local exit_code="$?"
   if [[ -n "$ORCH_PID" ]] && kill -0 "$ORCH_PID" >/dev/null 2>&1; then
@@ -215,8 +229,6 @@ echo "Building Maestro binary into $MAESTRO_BIN"
 "$ENSURE_DASHBOARD_DIST_BIN"
 go build -o "$MAESTRO_BIN" ./cmd/maestro
 
-PROJECT_ID="$("$MAESTRO_BIN" project create "Image E2E Project" --repo "$HARNESS_ROOT" --db "$DB_PATH" --quiet)"
-
 cat >"$WORKFLOW_PATH" <<EOF
 ---
 tracker:
@@ -271,6 +283,10 @@ Issue title: {{ issue.title }}
 Issue description:
 {{ issue.description }}
 EOF
+
+init_git_repo "$HARNESS_ROOT"
+
+PROJECT_ID="$("$MAESTRO_BIN" project create "Image E2E Project" --repo "$HARNESS_ROOT" --db "$DB_PATH" --quiet)"
 
 echo "Creating image e2e issue in $DB_PATH"
 ISSUE_IDENTIFIER="$("$MAESTRO_BIN" issue create "Read attached image text" --project "$PROJECT_ID" --desc "Inspect the attached image and answer with only the text shown in it." --db "$DB_PATH" --quiet)"

--- a/scripts/e2e_real_codex_phases.sh
+++ b/scripts/e2e_real_codex_phases.sh
@@ -27,6 +27,20 @@ require_cmd() {
   fi
 }
 
+init_git_repo() {
+  local repo_path="$1"
+  (
+    cd "$repo_path"
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_PREFIX
+    git init -q
+    git config user.name "Maestro E2E"
+    git config user.email "e2e@example.com"
+    git add WORKFLOW.md
+    git commit -q -m "test init"
+    git branch -M main
+  )
+}
+
 cleanup() {
   local exit_code="$?"
   stop_orchestrator
@@ -265,6 +279,8 @@ Requirements:
 3. Verify every file you create with shell commands before changing issue state.
 4. Stop immediately after the requested state transition succeeds.
 EOF
+
+init_git_repo "$HARNESS_ROOT"
 
 PROJECT_ID="$("$MAESTRO_BIN" project create "Real Codex E2E Phase Project" --repo "$HARNESS_ROOT" --db "$DB_PATH" --quiet)"
 start_project "$PROJECT_ID"

--- a/scripts/verify-pipeline.test.mjs
+++ b/scripts/verify-pipeline.test.mjs
@@ -42,6 +42,10 @@ test('verify:package keeps the real codex harness bootstrap regression test', ()
     pkg.includes('scripts/e2e_harness_bootstrap.test.sh'),
     'verify:package should keep the real codex harness bootstrap regression test',
   )
+  assert.ok(
+    pkg.includes('scripts/check_coverage.test.sh'),
+    'verify:package should keep the Bash compatibility regression test for coverage checks',
+  )
 })
 
 test('verify:pre-push keeps the full pre-push gate', () => {


### PR DESCRIPTION
## Task
Fix the recurring `Real Codex E2E` daily CI failure and publish the fix on a feature branch with verification evidence.

## Root Cause
The scheduled `Real Codex E2E` workflow began failing after workspace bootstrap started validating each project `--repo` path as a real Git repository. The three real-Codex harnesses were creating projects against a temporary harness root that had never been initialized as a Git repo, so Maestro aborted workspace bootstrap with `repo validation failed: fatal: not a git repository`.

While pushing the fix through the repo's enforced hooks, a second blocker appeared locally: `make test-cover` failed on macOS because `scripts/check_coverage.sh` used `declare -A`, which requires Bash 4+, while the system shell on this machine is Bash 3.2.

## What Changed
- initialized the temp harness repo in `scripts/e2e_real_codex.sh` before `project create`
- initialized the temp harness repo in `scripts/e2e_real_codex_phases.sh` before `project create`
- reordered the image harness so `WORKFLOW.md` is written, the temp repo is initialized, and only then `project create` runs in `scripts/e2e_real_codex_issue_images.sh`
- added a regression test in `scripts/e2e_harness_bootstrap.test.sh` that verifies the real-Codex harnesses create a valid repo with a tracked `WORKFLOW.md` and a commit on `main` before `project create`
- rewrote `scripts/check_coverage.sh` to avoid associative arrays and work under Bash 3.2 while preserving package de-duplication and exclusion behavior
- added `scripts/check_coverage.test.sh` to cover the Bash compatibility path with a mocked repo/toolchain
- wired the new coverage regression into `verify:package` and asserted its presence in `scripts/verify-pipeline.test.mjs`

## Verification
Ran locally under the enforced hooks/tooling path:

- `bash ./scripts/e2e_harness_bootstrap.test.sh`
- `bash ./scripts/check_coverage.test.sh`
- `bash -n scripts/e2e_real_codex.sh scripts/e2e_real_codex_phases.sh scripts/e2e_real_codex_issue_images.sh scripts/e2e_harness_bootstrap.test.sh scripts/check_coverage.sh scripts/check_coverage.test.sh`
- `bash -lc 'export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; export PATH="/usr/local/go/bin:$PATH"; make test-cover'`
- repo `pre-commit` / `pre-push` hooks via real `git commit` and `git push`
- full `verify:pre-push` gate during push, including Go build/test/race, coverage, web/package verification, package smoke, and `make e2e-retry-safety`

## Impact
- the nightly real-Codex workflow should no longer fail immediately on repo validation during workspace bootstrap
- local hook execution now works on the default macOS Bash version instead of requiring Bash 4+ semantics
