### PR TITLE
[codex] align real codex e2e harness parsing

### DIFF
--- a/docs/E2E_REAL_CODEX.md
+++ b/docs/E2E_REAL_CODEX.md
@@ -49,7 +49,7 @@ The image harness verifies the new app-server image path:
 
 - Maestro attaches a local PNG to an issue through the normal issue-image storage flow
 - the harness reuploads the fixture under an opaque filename so the expected OCR text is not leaked through image metadata
-- app-server mode stages that attachment into the issue workspace under `.maestro/issue-images`, and the staged bytes must match the original fixture exactly
+- app-server mode stages that attachment into the issue workspace under `.maestro/issue-assets`, and the staged bytes must match the original fixture exactly
 - the real Codex app-server receives the image as multimodal input and returns only `MAESTRO`
 - Maestro persists that final answer in issue activity, which the harness extracts from the raw final-answer payload and compares exactly
 

--- a/scripts/e2e_harness_bootstrap.test.sh
+++ b/scripts/e2e_harness_bootstrap.test.sh
@@ -195,6 +195,309 @@ EOF
     "$bin_dir/ensure-dashboard-dist"
 }
 
+make_issue_identifier_mock_toolchain() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'codex %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go %s\n' "$*" >>"$LOG_FILE"
+if [[ "${1:-}" != "build" ]]; then
+  exit 0
+fi
+
+output=""
+while (($#)); do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$output" ]]; then
+  printf 'missing go build output path\n' >>"$LOG_FILE"
+  exit 91
+fi
+
+cat >"$output" <<'INNER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'maestro %s\n' "$*" >>"$LOG_FILE"
+
+mode="${E2E_TEST_MODE:-}"
+create_count_file="$MOCK_HARNESS_ROOT/.issue-create-count"
+update_count_file="$MOCK_HARNESS_ROOT/.issue-update-count"
+move_count_file="$MOCK_HARNESS_ROOT/.issue-move-count"
+
+quiet_requested() {
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "--quiet" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+next_count() {
+  local path="$1"
+  local count
+  count="$(cat "$path" 2>/dev/null || printf '0')"
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$path"
+  printf '%s\n' "$count"
+}
+
+if [[ "${1:-}" == "project" && "${2:-}" == "create" ]]; then
+  printf 'proj_test\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+  count="$(next_count "$create_count_file")"
+  case "$mode:$count" in
+    basic:1) identifier="REAL-1" ;;
+    basic:2) identifier="REAL-2" ;;
+    phases:1) identifier="PHAS-1" ;;
+    phases:2) identifier="PHAS-2" ;;
+    *) exit 71 ;;
+  esac
+  if quiet_requested "$@"; then
+    printf '%s\n' "$identifier"
+  else
+    printf 'Created issue %s\n' "$identifier"
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "move" ]]; then
+  issue_id="${3:-}"
+  case "$issue_id" in
+    REAL-1|REAL-2) ;;
+    *) printf 'unexpected issue identifier for move: %s\n' "$issue_id" >>"$LOG_FILE"; exit 51 ;;
+  esac
+  count="$(next_count "$move_count_file")"
+  if [[ "$count" == "2" ]]; then
+    exit 61
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "update" ]]; then
+  issue_id="${3:-}"
+  case "$issue_id" in
+    PHAS-1|PHAS-2) ;;
+    *) printf 'unexpected issue identifier for update: %s\n' "$issue_id" >>"$LOG_FILE"; exit 52 ;;
+  esac
+  count="$(next_count "$update_count_file")"
+  if [[ "$count" == "2" ]]; then
+    exit 61
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "project" && "${2:-}" == "start" ]]; then
+  exit 0
+fi
+
+exit 72
+INNER
+chmod +x "$output"
+EOF
+
+  cat >"$bin_dir/sqlite3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'sqlite3 %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/ensure-dashboard-dist" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ensure-dashboard\n' >>"$LOG_FILE"
+EOF
+
+  chmod +x \
+    "$bin_dir/codex" \
+    "$bin_dir/go" \
+    "$bin_dir/sqlite3" \
+    "$bin_dir/ensure-dashboard-dist"
+}
+
+make_image_harness_mock_toolchain() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'codex %s\n' "$*" >>"$LOG_FILE"
+exit 0
+EOF
+
+  cat >"$bin_dir/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go %s\n' "$*" >>"$LOG_FILE"
+if [[ "${1:-}" != "build" ]]; then
+  exit 0
+fi
+
+output=""
+while (($#)); do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$output" ]]; then
+  printf 'missing go build output path\n' >>"$LOG_FILE"
+  exit 91
+fi
+
+cat >"$output" <<'INNER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'maestro %s\n' "$*" >>"$LOG_FILE"
+
+if [[ "${1:-}" == "project" && "${2:-}" == "create" ]]; then
+  printf 'proj_image\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "project" && "${2:-}" == "start" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+  printf 'IMAG-1\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "images" && "${3:-}" == "add" ]]; then
+  printf 'ast_img\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "move" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "show" ]]; then
+  if [[ -f "$MOCK_HARNESS_ROOT/.image-run-ready" ]]; then
+    cat <<'OUT'
+Identifier: IMAG-1
+Title: Read attached image text
+State: done
+OUT
+  else
+    cat <<'OUT'
+Identifier: IMAG-1
+Title: Read attached image text
+State: ready
+OUT
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "run" ]]; then
+  workspace_path="$MOCK_HARNESS_ROOT/workspaces/image-e2e-project/IMAG-1"
+  staged_dir="$workspace_path/.maestro/issue-assets"
+  staged_path="$staged_dir/ast_img-uploaded-issue-image.png"
+  mkdir -p "$staged_dir" "$MOCK_HARNESS_ROOT/.maestro"
+  cp "$MOCK_HARNESS_ROOT/uploaded-issue-image.png" "$staged_path"
+  python3 - <<'PY'
+import json
+import os
+import sqlite3
+
+root = os.environ["MOCK_HARNESS_ROOT"]
+db_path = os.path.join(root, ".maestro", "maestro.db")
+workspace_path = os.path.join(root, "workspaces", "image-e2e-project", "IMAG-1")
+
+conn = sqlite3.connect(db_path)
+conn.executescript(
+    """
+    CREATE TABLE IF NOT EXISTS issues (
+        id TEXT PRIMARY KEY,
+        identifier TEXT NOT NULL DEFAULT '',
+        title TEXT NOT NULL DEFAULT '',
+        state TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE IF NOT EXISTS workspaces (
+        issue_id TEXT PRIMARY KEY,
+        path TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE IF NOT EXISTS issue_activity_entries (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        issue_id TEXT NOT NULL DEFAULT '',
+        identifier TEXT NOT NULL DEFAULT '',
+        kind TEXT NOT NULL DEFAULT '',
+        phase TEXT NOT NULL DEFAULT '',
+        raw_payload_json TEXT NOT NULL DEFAULT '{}',
+        attempt INTEGER NOT NULL DEFAULT 0
+    );
+    DELETE FROM issues;
+    DELETE FROM workspaces;
+    DELETE FROM issue_activity_entries;
+    """
+)
+conn.execute(
+    "INSERT INTO issues (id, identifier, title, state) VALUES (?, ?, ?, ?)",
+    ("iss_img", "IMAG-1", "Read attached image text", "done"),
+)
+conn.execute(
+    "INSERT INTO workspaces (issue_id, path) VALUES (?, ?)",
+    ("iss_img", workspace_path),
+)
+conn.execute(
+    "INSERT INTO issue_activity_entries (issue_id, identifier, kind, phase, raw_payload_json, attempt) VALUES (?, ?, ?, ?, ?, ?)",
+    ("iss_img", "IMAG-1", "agent", "final_answer", json.dumps({"item": {"text": "MAESTRO"}}), 0),
+)
+conn.commit()
+conn.close()
+PY
+  : >"$MOCK_HARNESS_ROOT/.image-run-ready"
+  exit 0
+fi
+
+exit 72
+INNER
+chmod +x "$output"
+EOF
+
+  cat >"$bin_dir/ensure-dashboard-dist" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ensure-dashboard\n' >>"$LOG_FILE"
+EOF
+
+  chmod +x \
+    "$bin_dir/codex" \
+    "$bin_dir/go" \
+    "$bin_dir/ensure-dashboard-dist"
+}
+
 cleanup_sentinel() {
   rm -f "$ROOT_DIR/internal/dashboardui/dist/.e2e-bootstrap-sentinel"
 }
@@ -286,9 +589,81 @@ test_scripts_initialize_git_repo_before_project_create() {
   done
 }
 
+test_scripts_use_quiet_issue_identifiers() {
+  local scripts=(
+    "$ROOT_DIR/scripts/e2e_real_codex.sh:basic:REAL-1:REAL-2"
+    "$ROOT_DIR/scripts/e2e_real_codex_phases.sh:phases:PHAS-1:PHAS-2"
+  )
+
+  local entry
+  for entry in "${scripts[@]}"; do
+    local script mode first_identifier second_identifier tmp_dir bin_dir log_file stdout_file stderr_file harness_root
+    IFS=: read -r script mode first_identifier second_identifier <<<"$entry"
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/e2e-harness-identifiers.XXXXXX")"
+    bin_dir="$tmp_dir/bin"
+    log_file="$tmp_dir/log.txt"
+    stdout_file="$tmp_dir/stdout.txt"
+    stderr_file="$tmp_dir/stderr.txt"
+    harness_root="$tmp_dir/harness"
+
+    make_issue_identifier_mock_toolchain "$bin_dir"
+    : >"$log_file"
+
+    if PATH="$bin_dir:/usr/bin:/bin" \
+      LOG_FILE="$log_file" \
+      MOCK_HARNESS_ROOT="$harness_root" \
+      E2E_TEST_MODE="$mode" \
+      MAESTRO_ENSURE_DASHBOARD_DIST_BIN="$bin_dir/ensure-dashboard-dist" \
+      E2E_ROOT="$harness_root" \
+      bash "$script" >"$stdout_file" 2>"$stderr_file"; then
+      fail "expected $(basename "$script") to stop after the mocked identifier path"
+    fi
+
+    assert_contains "$log_file" "maestro issue create"
+    case "$mode" in
+      basic)
+        assert_contains "$log_file" "maestro issue move $first_identifier ready --db"
+        assert_contains "$log_file" "maestro issue move $second_identifier ready --db"
+        ;;
+      phases)
+        assert_contains "$log_file" "maestro issue update $first_identifier --desc"
+        assert_contains "$log_file" "maestro issue update $second_identifier --desc"
+        ;;
+    esac
+  done
+}
+
+test_image_harness_uses_project_workspace_and_issue_assets_dir() {
+  local tmp_dir bin_dir log_file stdout_file stderr_file harness_root
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/e2e-harness-images.XXXXXX")"
+  bin_dir="$tmp_dir/bin"
+  log_file="$tmp_dir/log.txt"
+  stdout_file="$tmp_dir/stdout.txt"
+  stderr_file="$tmp_dir/stderr.txt"
+  harness_root="$tmp_dir/harness"
+
+  make_image_harness_mock_toolchain "$bin_dir"
+  : >"$log_file"
+
+  PATH="$bin_dir:/usr/bin:/bin" \
+    LOG_FILE="$log_file" \
+    MOCK_HARNESS_ROOT="$harness_root" \
+    MAESTRO_ENSURE_DASHBOARD_DIST_BIN="$bin_dir/ensure-dashboard-dist" \
+    E2E_ROOT="$harness_root" \
+    E2E_KEEP_HARNESS=0 \
+    bash "$ROOT_DIR/scripts/e2e_real_codex_issue_images.sh" >"$stdout_file" 2>"$stderr_file"
+
+  assert_contains "$log_file" "maestro run $harness_root --workflow $harness_root/WORKFLOW.md --db $harness_root/.maestro/maestro.db --port"
+  assert_contains "$stdout_file" "Real Codex app-server image e2e flow completed successfully."
+  assert_contains "$stdout_file" "staged image -> $harness_root/workspaces/image-e2e-project/IMAG-1/.maestro/issue-assets/ast_img-uploaded-issue-image.png"
+  assert_contains "$stdout_file" "final answer MAESTRO"
+}
+
 main() {
   test_scripts_bootstrap_dashboard_dist_before_build
   test_scripts_initialize_git_repo_before_project_create
+  test_scripts_use_quiet_issue_identifiers
+  test_image_harness_uses_project_workspace_and_issue_assets_dir
 }
 
 main "$@"

--- a/scripts/e2e_real_codex.sh
+++ b/scripts/e2e_real_codex.sh
@@ -185,8 +185,8 @@ PROJECT_ID="$("$MAESTRO_BIN" project create "Real Codex E2E Project" --repo "$HA
 start_project "$PROJECT_ID"
 
 echo "Creating e2e issues in $DB_PATH"
-ISSUE_ONE="$("$MAESTRO_BIN" issue create "Create first e2e artifact" --project "$PROJECT_ID" --desc "Create file artifact-one.txt in the shared artifacts directory with exactly this single line of text: maestro e2e ok 1" --db "$DB_PATH" | sed -E 's/^Created issue ([^:]+): .*$/\1/')"
-ISSUE_TWO="$("$MAESTRO_BIN" issue create "Create second e2e artifact" --project "$PROJECT_ID" --desc "Create file artifact-two.txt in the shared artifacts directory with exactly this single line of text: maestro e2e ok 2" --db "$DB_PATH" | sed -E 's/^Created issue ([^:]+): .*$/\1/')"
+ISSUE_ONE="$("$MAESTRO_BIN" issue create "Create first e2e artifact" --project "$PROJECT_ID" --desc "Create file artifact-one.txt in the shared artifacts directory with exactly this single line of text: maestro e2e ok 1" --db "$DB_PATH" --quiet)"
+ISSUE_TWO="$("$MAESTRO_BIN" issue create "Create second e2e artifact" --project "$PROJECT_ID" --desc "Create file artifact-two.txt in the shared artifacts directory with exactly this single line of text: maestro e2e ok 2" --db "$DB_PATH" --quiet)"
 
 "$MAESTRO_BIN" issue move "$ISSUE_ONE" ready --db "$DB_PATH" >/dev/null
 "$MAESTRO_BIN" issue move "$ISSUE_TWO" ready --db "$DB_PATH" >/dev/null

--- a/scripts/e2e_real_codex_issue_images.sh
+++ b/scripts/e2e_real_codex_issue_images.sh
@@ -72,6 +72,31 @@ issue_title() {
   "$MAESTRO_BIN" issue show "$1" --db "$DB_PATH" | awk -F': *' '/^Title:/{sub(/^ +/, "", $2); print $2}'
 }
 
+workspace_path_for_issue() {
+  local issue_identifier="$1"
+  python3 - "$DB_PATH" "$issue_identifier" <<'PY'
+import sqlite3
+import sys
+
+db_path, issue_identifier = sys.argv[1:3]
+conn = sqlite3.connect(db_path)
+row = conn.execute(
+    """
+    SELECT w.path
+    FROM workspaces AS w
+    JOIN issues AS i ON i.id = w.issue_id
+    WHERE i.identifier = ?
+    LIMIT 1
+    """,
+    (issue_identifier,),
+).fetchone()
+conn.close()
+if not row or not row[0]:
+    raise SystemExit(1)
+print(row[0])
+PY
+}
+
 fixture_upload_path() {
   local fixture_path="$1"
   local fixture_name ext
@@ -194,7 +219,7 @@ PY
 find_staged_image_path() {
   local workspace_path="$1"
   local image_id="$2"
-  local stage_dir="$workspace_path/.maestro/issue-images"
+  local stage_dir="$workspace_path/.maestro/issue-assets"
   local match_count=0
   local match_path=""
   local path
@@ -320,7 +345,10 @@ if ! wait_for_done "$ISSUE_IDENTIFIER"; then
   exit 1
 fi
 
-WORKSPACE_PATH="$WORKSPACES_DIR/$ISSUE_IDENTIFIER"
+if ! WORKSPACE_PATH="$(workspace_path_for_issue "$ISSUE_IDENTIFIER")"; then
+  echo "failed to resolve workspace path for $ISSUE_IDENTIFIER from $DB_PATH" >&2
+  exit 1
+fi
 STAGED_IMAGE_PATH="$(find_staged_image_path "$WORKSPACE_PATH" "$IMAGE_ID")"
 assert_file_exists "$STAGED_IMAGE_PATH"
 assert_files_identical "$IMAGE_FIXTURE" "$STAGED_IMAGE_PATH" "staged image"

--- a/scripts/e2e_real_codex_phases.sh
+++ b/scripts/e2e_real_codex_phases.sh
@@ -286,8 +286,8 @@ PROJECT_ID="$("$MAESTRO_BIN" project create "Real Codex E2E Phase Project" --rep
 start_project "$PROJECT_ID"
 
 echo "Creating phase e2e issues in $DB_PATH"
-ISSUE_REVIEW="$("$MAESTRO_BIN" issue create "Phase flow through review" --project "$PROJECT_ID" --desc "placeholder" --db "$DB_PATH" | sed -E 's/^Created issue ([^:]+): .*$/\1/')"
-ISSUE_SKIP="$("$MAESTRO_BIN" issue create "Phase flow skipping review" --project "$PROJECT_ID" --desc "placeholder" --db "$DB_PATH" | sed -E 's/^Created issue ([^:]+): .*$/\1/')"
+ISSUE_REVIEW="$("$MAESTRO_BIN" issue create "Phase flow through review" --project "$PROJECT_ID" --desc "placeholder" --db "$DB_PATH" --quiet)"
+ISSUE_SKIP="$("$MAESTRO_BIN" issue create "Phase flow skipping review" --project "$PROJECT_ID" --desc "placeholder" --db "$DB_PATH" --quiet)"
 
 update_issue_description "$ISSUE_REVIEW" "$(cat <<EOF
 Implementation-phase requirements for $ISSUE_REVIEW:


### PR DESCRIPTION
## What changed
- Made the real Codex e2e harnesses stop depending on the old `Created issue ...:` output shape by requesting quiet issue identifiers.
- Updated the image harness to resolve the workspace from the database and to look for staged files in `.maestro/issue-assets`, which matches the runtime.
- Added regression coverage in the harness bootstrap test and updated the e2e docs to reflect the current asset path.

## Why
The `real-codex-e2e` GitHub Actions job was failing because the harnesses were assuming stale CLI and filesystem behavior:
- issue creation output no longer matched the old parser
- the image flow was still looking in `.maestro/issue-images` even though staging now happens under `.maestro/issue-assets`

## Impact
This restores the three real e2e matrix paths:
- basic issue flow
- phase/restart flow
- image attachment flow

## Verification
- `bash ./scripts/e2e_harness_bootstrap.test.sh`
- `bash -n scripts/e2e_real_codex.sh scripts/e2e_real_codex_phases.sh scripts/e2e_real_codex_issue_images.sh scripts/e2e_harness_bootstrap.test.sh`
- `git diff --check`
- `bash ./scripts/e2e_real_codex.sh` with `E2E_KEEP_HARNESS=1`
- `bash ./scripts/e2e_real_codex_phases.sh` with `E2E_KEEP_HARNESS=1`
- `bash ./scripts/e2e_real_codex_issue_images.sh` with `E2E_KEEP_HARNESS=1`