### PR TITLE
fix(maestro): pin image e2e app-server model

### DIFF
--- a/scripts/e2e_real_codex_issue_images.sh
+++ b/scripts/e2e_real_codex_issue_images.sh
@@ -281,7 +281,9 @@ agent:
   max_retry_backoff_ms: 5000
   mode: app_server
 codex:
-  command: codex app-server
+  # Pin the app-server model so multimodal behavior stays deterministic across
+  # local ChatGPT logins and GitHub Actions API-key runs.
+  command: codex app-server -c 'model="gpt-5.3-codex"'
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:


### PR DESCRIPTION
## Summary
- Investigated the failing `Real Codex E2E #38` `issue-images` job, which timed out waiting for `IMAG-1` to reach `done`
- Pinned the generated `codex app-server` command to `gpt-5.3-codex` in `scripts/e2e_real_codex_issue_images.sh` so the image harness behaves deterministically across local ChatGPT logins and GitHub Actions API-key runs
- Kept the change narrowly scoped to the e2e harness that was failing in CI

## Verification
- `bash -n scripts/e2e_real_codex_issue_images.sh`
- `git diff --check`
- `bash scripts/e2e_real_codex_issue_images.sh`
- `git push -u origin codex/fix-image-e2e-model` completed after the repo pre-push gate passed

## Context
This was done to stabilize the image-based e2e flow that had previously stalled in GitHub Actions on `IMAG-1` before the fix.