### PR TITLE
[codex] Remove daily CI jobs

### DIFF
--- a/.github/workflows/real-codex-e2e.yml
+++ b/.github/workflows/real-codex-e2e.yml
@@ -2,8 +2,6 @@ name: Real Codex E2E
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '15 3 * * *'
 
 permissions:
   contents: read

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -1845,11 +1845,21 @@ func TestServiceGetIssueByIdentifierColdMissQueriesProjectsInParallel(t *testing
 		}
 	}
 
+	var active atomic.Int32
+	var maxActive atomic.Int32
 	var started atomic.Int32
 	svc := NewService(store)
 	svc.providers["stub"] = &stubProvider{
 		kind: "stub",
 		getFunc: func(ctx context.Context, project *kanban.Project, identifier string) (*kanban.Issue, error) {
+			current := active.Add(1)
+			defer active.Add(-1)
+			for {
+				observed := maxActive.Load()
+				if current <= observed || maxActive.CompareAndSwap(observed, current) {
+					break
+				}
+			}
 			started.Add(1)
 			for started.Load() < int32(len(projectRefs)) {
 				select {
@@ -1873,7 +1883,6 @@ func TestServiceGetIssueByIdentifierColdMissQueriesProjectsInParallel(t *testing
 		},
 	}
 
-	start := time.Now()
 	issue, err := svc.GetIssueByIdentifier(context.Background(), "STUB-FAST-1")
 	if err != nil {
 		t.Fatalf("GetIssueByIdentifier: %v", err)
@@ -1881,8 +1890,8 @@ func TestServiceGetIssueByIdentifierColdMissQueriesProjectsInParallel(t *testing
 	if issue.Identifier != "STUB-FAST-1" {
 		t.Fatalf("unexpected issue returned: %#v", issue)
 	}
-	if elapsed := time.Since(start); elapsed >= 40*time.Millisecond {
-		t.Fatalf("expected parallel provider probes, lookup took %v", elapsed)
+	if got := maxActive.Load(); got != int32(len(projectRefs)) {
+		t.Fatalf("expected all provider probes to overlap, max active probes=%d", got)
 	}
 }
 


### PR DESCRIPTION
## Task

Remove any daily CI jobs from CI so expensive real-Codex E2E coverage no longer runs on a daily schedule.

## Changes

- Removed the `schedule` cron trigger from `.github/workflows/real-codex-e2e.yml`.
- Kept `workflow_dispatch` so the real Codex E2E workflow remains runnable manually.
- Hardened `TestServiceGetIssueByIdentifierColdMissQueriesProjectsInParallel` to assert overlapping provider probes directly instead of relying on a tight wall-clock threshold that failed under `-race` during the pre-push gate.

## Validation

- `rg -n "cron:|schedule:|daily|nightly" .github/workflows` returned no matches.
- Commit hook for provider test commit: `go test ./internal/providers` passed.
- Targeted race test: `go test -race ./internal/providers -run TestServiceGetIssueByIdentifierColdMissQueriesProjectsInParallel -count=1 -v` passed.
- Provider package checks: `go test ./internal/providers -count=1 && go test -race ./internal/providers -count=1` passed.
- Full pre-push hook `pnpm verify:pre-push` passed, including Go tests, Go coverage threshold, Go race tests, frontend/website checks, package smoke, and `make e2e-retry-safety`.

## Notes

The first pre-push attempt ran against unrelated unstaged local edits and failed coverage for `internal/appserver/protocol`. Those edits were stashed before pushing this branch. A clean pre-push run then exposed the provider test timing flake, which is fixed in this PR.